### PR TITLE
Fixed avif decoding image size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,7 @@ impl<'a> Decoder<'a> {
             };
 
             let pixels = unsafe {
-                std::slice::from_raw_parts(rgb.pixels, (rgb.width * rgb.height) as usize)
+                std::slice::from_raw_parts(rgb.pixels, (rgb.width * rgb.height * 4) as usize)
             };
 
             result = Ok(ImageData::new(


### PR DESCRIPTION
Fixed avif decoding to rgba format. Previous behavior: image slice returned from decode_avif function was 4 times smaller than actually is.