### PR TITLE
Allow reading of Tiff images (supported in rs-image)

### DIFF
--- a/src/config/image_format.rs
+++ b/src/config/image_format.rs
@@ -9,6 +9,8 @@ pub enum ImageFormat {
     Jpeg,
     /// PNG image format.
     Png,
+    /// TIFF image format.
+    Tiff,
     /// JPEG XL image format.
     #[cfg(feature = "jxl")]
     JpegXl,
@@ -55,6 +57,7 @@ impl ImageFormat {
             {
                 "jpg" | "jpeg" => Self::Jpeg,
                 "png" => Self::Png,
+                "tiff" | "tif" => Self::Tiff,
                 #[cfg(feature = "jxl")]
                 "jxl" => Self::JpegXl,
                 #[cfg(feature = "webp")]


### PR DESCRIPTION
Since rs-image is used for decoding by default, any image format supported there can technically be decoded.

I've added Tiff here as a format in the enumeration so that rimage will accept reading .tif or .tiff files.