### PR TITLE
change tips to match the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Options:
   -V, --version  Print version
 
 General:
-  -q, --quality <QUALITY>         Optimization image quality, disabled when use Jpegxl format
+  -q, --quality <QUALITY>         Optimization image quality, disabled when use Jxl format
                                   [range: 1 - 100] [default: 75]
-  -f, --codec <CODEC>             Image codec to use
-                                  [default: jpg] [possible values: png, oxipng, jpegxl, webp, avif]
+  -f, --codec <CODEC>             Image codec for output
+                                  [possible values: jpg, png, oxipng, jxl, webp, avif] [default: jpg]
   -o, --output <DIR>              Write output file(s) to <DIR>, if "-r" option is not used
   -r, --recursive                 Saves output file(s) preserving folder structure
   -s, --suffix [<SUFFIX>]         Appends suffix to output file(s) names
@@ -76,14 +76,37 @@ Resizing:
       --height <HEIGHT>           Resize image with specified height
                                   [integer only]
       --filter <FILTER>           Filter used for image resizing
-                                  [possible values: point, triangle, catrom, mitchell] [default: lanczos3]
+                                  [possible values: point, triangle, catrom, mitchell, lanczos3] [default: lanczos3]
 ```
 
 Note that image formats may wary from features that are used when building `rimage`.
 
-_Full_ List of supported codecs with all features:
+### List of supprted codec (Format)
 
-- `mozjpeg`, `jpeg`, `jpg` => **mozjpeg codec (common and small)**
+| Codec (Format)             | Input | Output | Notes                      |
+| -------------------------- | ----- | ------ | -------------------------- |
+| `avif`                     | √     | √      |                            |
+| **`jpg`/`jpeg`/`mozjpeg`** | √     | √      | **DEFAULT**, Common&Small  |
+| `webp`                     | √     | √      |                            |
+| **`png`**                  | √     | √      |                            |
+| -------------------------- | ----- | ------ | -------------------------- |
+| `jxl`/`jpegxl`             | √     | √ \| X | `-q` opinion is disabled   |
+| `oxipng`                   | X     | √      |                            |
+| -------------------------- | ----- | ------ | -------------------------- |
+| `bmp`                      | √     | X      |                            |
+| `dds`                      | √     | X      |                            |
+| `exr`                      | √     | X      |                            |
+| `ff`/`farbfeld`            | √     | X      |                            |
+| `gif`                      | √     | X      |                            |
+| `hdr`                      | √     | X      |                            |
+| `ico`                      | √     | X      |                            |
+| `pam`/`pbm`/`pgm`/`ppm`    | √     | X      |                            |
+| `qoi`                      | √     | X      |                            |
+| `tga`                      | √     | X      |                            |
+| `tif`/`tiff`               | √     | X      |                            |
+
+_Full_ List of supported **output** codecs with all features:
+
 - `png` => browser png codec without compression
 - `oxipng` => oxipng codec with compression
 - `jpegxl`, `jxl` => jpeg xl codec

--- a/src/bin/rimage/main.rs
+++ b/src/bin/rimage/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let matches = Command::new("rimage")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Vladyslav Vladinov <vladinov.dev@gmail.com>")
-        .about("A tool to convert/optimize/resize images in different formats")
+        .about("Rimage is a tool to convert/optimize/resize images in different formats")
         .arg(
             arg!(<FILES> "Input file(s) to process")
                 .num_args(1..)
@@ -21,10 +21,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         )
         .next_help_heading("General")
         .args([
-            arg!(-q --quality <QUALITY> "Optimization image quality, disabled when use Jpegxl format\n[range: 1 - 100]")
+            arg!(-q --quality <QUALITY> "Optimization image quality, disabled when use Jxl format\n[range: 1 - 100]")
                 .value_parser(value_parser!(f32))
                 .default_value("75"),
-            arg!(-f --codec <CODEC> "Image codec to use\n[possible values: png, oxipng, jpegxl, webp, avif]")
+            arg!(-f --codec <CODEC> "Image codec for output\n[possible values: jpg, png, oxipng, jxl, webp, avif]")
                 .value_parser(Codec::from_str)
                 .default_value("mozjpeg"),
             arg!(-o --output <DIR> "Write output file(s) to <DIR>, if \"-r\" option is not used")


### PR DESCRIPTION
1. Add a table in README to introduce the full list of format that Rimage supported
2. Modify the help text of `-f` opinion to disambiguate
3. Update the tips in main.rs