### PR TITLE
Tips

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = ["/README.md", "/Cargo.toml", "/src/**/*.rs"]
 [profile.release]
 lto = true
 codegen-units = 1
+strip = true
 
 [[bin]]
 name = "rimage"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For library usage check [Docs.rs](https://docs.rs/rimage/latest/rimage/)
 
 | Image Format | Decoder       | Encoder                 | NOTE                                                 |
 | ------------ | ------------- | ----------------------- | ---------------------------------------------------- |
-| bmp          | zune-bmp      | -                       | Input only                                           |
+| bmp          | zune-bmp      | X                       | Input only                                           |
 | jpeg         | zune-jpeg     | mozjpeg or jpeg-encoder |                                                      |
 | png          | zune-png      | oxipng or zune-png      | Static pics only                                     |
 | avif         | libavif       | ravif                   | Only common features are supported, Static pics only |
@@ -47,7 +47,7 @@ For library usage check [Docs.rs](https://docs.rs/rimage/latest/rimage/)
 | ppm          | zune-ppm      | zune-ppm                |                                                      |
 | qoi          | zune-qoi      | zune-qoi                |                                                      |
 | farbfeld     | zune-farbfeld | zune-farbfeld           |                                                      |
-| psd          | zune-psd      | -                       | Input only                                           |
+| psd          | zune-psd      | X                       | Input only                                           |
 | jpeg-xl      | jxl-oxide     | zune-jpegxl             | Lossless Output only                                 |
 | hdr          | zune-hdr      | zune-hdr                |                                                      |
 

--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ For library usage check [Docs.rs](https://docs.rs/rimage/latest/rimage/)
 
 ### List of supported Codecs
 
-| Image Format | Decoder       | Encoder                 |
-| ------------ | ------------- | ----------------------- |
-| bmp          | zune-bmp      | -                       |
-| jpeg         | zune-jpeg     | mozjpeg or jpeg-encoder |
-| png          | zune-png      | oxipng or zune-png      |
-| avif         | libavif       | ravif                   |
-| webp         | webp          | webp                    |
-| ppm          | zune-ppm      | zune-ppm                |
-| qoi          | zune-qoi      | zune-qoi                |
-| farbfeld     | zune-farbfeld | zune-farbfeld           |
-| psd          | zune-psd      | -                       |
-| jpeg-xl      | jxl-oxide     | zune-jpegxl             |
-| hdr          | zune-hdr      | zune-hdr                |
+| Image Format | Decoder       | Encoder                 | NOTE                                                 |
+| ------------ | ------------- | ----------------------- | ---------------------------------------------------- |
+| bmp          | zune-bmp      | -                       | Input only                                           |
+| jpeg         | zune-jpeg     | mozjpeg or jpeg-encoder |                                                      |
+| png          | zune-png      | oxipng or zune-png      | Static pics only                                     |
+| avif         | libavif       | ravif                   | Only common features are supported, Static pics only |
+| webp         | webp          | webp                    | Static pics only                                     |
+| ppm          | zune-ppm      | zune-ppm                |                                                      |
+| qoi          | zune-qoi      | zune-qoi                |                                                      |
+| farbfeld     | zune-farbfeld | zune-farbfeld           |                                                      |
+| psd          | zune-psd      | -                       | Input only                                           |
+| jpeg-xl      | jxl-oxide     | zune-jpegxl             | Lossless Output only                                 |
+| hdr          | zune-hdr      | zune-hdr                |                                                      |
 
 ### List of supported preprocessing options
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,47 +14,47 @@ pub fn cli() -> Command {
     command!()
         .arg_required_else_help(true)
         .arg(
-            arg!([files] ... "Input file(s) to process")
-                .long_help(indoc! {"Input file(s) to process
+            arg!([files] "Input file(s) to process.")
+                .long_help(indoc! {r#"Input file(s) to process.
 
-                If the file path contains spaces, enclose the path with double quotation marks on both sides."})
+                If the file path contains spaces, enclose the path with double quotation marks on both sides."#})
                 .value_parser(value_parser!(PathBuf))
                 .global(true)
                 .last(true),
         )
         .arg(
-            arg!(-d --directory <DIR> "The directory to write output file(s) to")
-                .long_help(indoc! {"The directory to write output file(s) to
+            arg!(-d --directory <DIR> "The directory to write output file(s) to.")
+                .long_help(indoc! {r#"The directory to write output file(s) to.
 
-                Output files will be written without preserving the folder structure unless the --recursive flag is used."})
+                Output files will be written without preserving the folder structure unless the --recursive flag is used."#})
                 .value_parser(value_parser!(PathBuf)),
         )
         .arg(
-            arg!(-r --recursive "Preserves the folder structure when writing output file(s)")
-                .long_help(indoc! {"Preserves the folder structure when writing output file(s).
+            arg!(-r --recursive "Preserves the folder structure when writing output file(s).")
+                .long_help(indoc! {r#"Preserves the folder structure when writing output file(s).
 
-                This option should be used in conjunction with the --directory option."})
+                This option should be used in conjunction with the --directory option."#})
                 .requires("directory"),
         )
         .arg(
-            arg!(-s --suffix [SUFFIX] "Adds the '@suffix' to the names of output file(s)")
-                .long_help(indoc! {"Adds the '@suffix' to the names of output file(s)
+            arg!(-s --suffix [SUFFIX] "Adds the '@suffix' to the names of output file(s).")
+                .long_help(indoc! {r#"Adds the '@suffix' to the names of output file(s).
 
                 When '2x' is provided as the value, the resulting files will be renamed with the '@2x' suffix.
                 For example, a file named 'file.jpeg' will become 'file@2x.jpeg'.
 
-                If no suffix is provided, the default updated suffix '@updated' will be added to the resulting files."})
+                If no suffix is provided, the default updated suffix '@updated' will be added to the resulting files."#})
                 .default_missing_value("updated"),
         )
         .arg(
-            arg!(-b --backup "Adds the '@backup' to the names of input file(s)")
+            arg!(-b --backup "Adds the '@backup' to the names of input file(s).")
         )
         .arg(
-            arg!(-t --threads <NUM> "The number of threads for concurrent processing")
-                .long_help(indoc! {"The number of threads for concurrent processing
+            arg!(-t --threads <NUM> "The number of threads for concurrent processing.")
+                .long_help(indoc! {r#"The number of threads for concurrent processing.
 
                 Usage of multiple threads can speed up the execution of tasks, especially on multi-core processors.
-                By default, the number of available threads is utilized"})
+                By default, the number of available threads is utilized."#})
                 .value_parser(value_parser!(u8).range(1..=threads::num_threads() as i64)),
         )
         .preprocessors()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ pub fn cli() -> Command {
     command!()
         .arg_required_else_help(true)
         .arg(
-            arg!([files] "Input file(s) to process.")
+            arg!([files] ... "Input file(s) to process.")
                 .long_help(indoc! {r#"Input file(s) to process.
 
                 If the file path contains spaces, enclose the path with double quotation marks on both sides."#})

--- a/src/cli/codecs/avif.rs
+++ b/src/cli/codecs/avif.rs
@@ -5,22 +5,22 @@ pub fn avif() -> Command {
     Command::new("avif")
         .about("Encode images into AVIF format")
         .args([
-            arg!(-q --quality <NUM> "Quality which the image will be encoded with")
+            arg!(-q --quality <NUM> "Quality which the image will be encoded with.")
                 .value_parser(value_parser!(u8).range(1..=100))
                 .default_value("50"),
-            arg!(--alpha_quality <NUM> "Separate alpha quality which the image will be encoded with")
+            arg!(--alpha_quality <NUM> "Separate alpha quality which the image will be encoded with.")
                 .value_parser(value_parser!(u8).range(1..=100)),
-            arg!(--speed <NUM> "Compression speed (effort)")
-                .long_help(indoc! {"Compression speed (effort)
+            arg!(--speed <NUM> "Compression speed (effort).")
+                .long_help(indoc! {r#"Compression speed (effort).
 
-                1 = very very slow, but max compression
-                10 = quick, but larger file sizes and lower quality."})
+                1 = very very slow, but max compression (smallest)
+                10 = quick, but larger file sizes and lower quality."#})
                 .value_parser(value_parser!(u8).range(1..=10))
                 .default_value("6"),
-            arg!(--colorspace <COLOR> "Set color space of AVIF being written")
+            arg!(--colorspace <COLOR> "Set color space of AVIF being written.")
                 .value_parser(["ycbcr", "rgb"])
                 .default_value("ycbcr"),
-            arg!(--alpha_mode <MODE> "Configure handling of color channels in transparent images")
+            arg!(--alpha_mode <MODE> "Configure handling of color channels in transparent images.")
                 .value_parser(["UnassociatedDirty", "UnassociatedClean", "Premultiplied"])
                 .default_value("UnassociatedClean")
         ])

--- a/src/cli/codecs/avif.rs
+++ b/src/cli/codecs/avif.rs
@@ -3,7 +3,7 @@ use indoc::indoc;
 
 pub fn avif() -> Command {
     Command::new("avif")
-        .about("Encode images into AVIF format")
+        .about("Encode images into AVIF format. (Small and Efficient)")
         .args([
             arg!(-q --quality <NUM> "Quality which the image will be encoded with.")
                 .value_parser(value_parser!(u8).range(1..=100))

--- a/src/cli/codecs/farbfeld.rs
+++ b/src/cli/codecs/farbfeld.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn farbfeld() -> Command {
-    Command::new("farbfeld").about("Encode images into Farbfeld format")
+    Command::new("farbfeld").about("Encode images into Farbfeld format. (Uncommon)")
 }

--- a/src/cli/codecs/farbfeld.rs
+++ b/src/cli/codecs/farbfeld.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn farbfeld() -> Command {
-    Command::new("farbfeld").about("Encode images into Farbfeld format. (Uncommon)")
+    Command::new("farbfeld").about("Encode images into Farbfeld format. (Bitmapped)")
 }

--- a/src/cli/codecs/jpeg.rs
+++ b/src/cli/codecs/jpeg.rs
@@ -3,7 +3,7 @@ use clap::{arg, value_parser, Command};
 pub fn jpeg() -> Command {
     Command::new("jpeg")
         .alias("jpg")
-        .about("Encode images into JPEG format. (Common and Progressive-able)")
+        .about("Encode images into JPEG format. (Progressive-able)")
         .args([
             arg!(-q --quality <NUM> "Quality which the image will be encoded with.")
                 .value_parser(value_parser!(u8).range(1..=100)),

--- a/src/cli/codecs/jpeg.rs
+++ b/src/cli/codecs/jpeg.rs
@@ -3,7 +3,7 @@ use clap::{arg, value_parser, Command};
 pub fn jpeg() -> Command {
     Command::new("jpeg")
         .alias("jpg")
-        .about("Encode images into JPEG format.")
+        .about("Encode images into JPEG format. (Common and Progressive-able)")
         .args([
             arg!(-q --quality <NUM> "Quality which the image will be encoded with.")
                 .value_parser(value_parser!(u8).range(1..=100)),

--- a/src/cli/codecs/jpeg.rs
+++ b/src/cli/codecs/jpeg.rs
@@ -3,10 +3,10 @@ use clap::{arg, value_parser, Command};
 pub fn jpeg() -> Command {
     Command::new("jpeg")
         .alias("jpg")
-        .about("Encode images into JPEG format")
+        .about("Encode images into JPEG format.")
         .args([
-            arg!(-q --quality <NUM> "Quality which the image will be encoded with")
+            arg!(-q --quality <NUM> "Quality which the image will be encoded with.")
                 .value_parser(value_parser!(u8).range(1..=100)),
-            arg!(--progressive "Set to use progressive encoding"),
+            arg!(--progressive "Set to use progressive encoding."),
         ])
 }

--- a/src/cli/codecs/jpeg_xl.rs
+++ b/src/cli/codecs/jpeg_xl.rs
@@ -4,7 +4,7 @@ use indoc::indoc;
 pub fn jpeg_xl() -> Command {
     Command::new("jpeg_xl")
         .alias("jxl")
-        .about("Encode images into jpeg xl format.")
+        .about("Encode images into jpeg xl format. (Big but Lossless)")
         .long_about(indoc! {r#"Encode images into jpeg xl format.
 
         Only supports lossless encoding"#})

--- a/src/cli/codecs/jpeg_xl.rs
+++ b/src/cli/codecs/jpeg_xl.rs
@@ -4,7 +4,7 @@ use indoc::indoc;
 pub fn jpeg_xl() -> Command {
     Command::new("jpeg_xl")
         .alias("jxl")
-        .about("Encode images into jpeg xl format. (Big but Lossless)")
+        .about("Encode images into JpegXL format. (Big but Lossless)")
         .long_about(indoc! {r#"Encode images into jpeg xl format.
 
         Only supports lossless encoding"#})

--- a/src/cli/codecs/jpeg_xl.rs
+++ b/src/cli/codecs/jpeg_xl.rs
@@ -4,8 +4,8 @@ use indoc::indoc;
 pub fn jpeg_xl() -> Command {
     Command::new("jpeg_xl")
         .alias("jxl")
-        .about("Encode images into jpeg xl format")
-        .long_about(indoc! {"Encode images into jpeg xl format
+        .about("Encode images into jpeg xl format.")
+        .long_about(indoc! {r#"Encode images into jpeg xl format.
 
-        Only supports lossless encoding"})
+        Only supports lossless encoding"#})
 }

--- a/src/cli/codecs/mozjpeg.rs
+++ b/src/cli/codecs/mozjpeg.rs
@@ -3,7 +3,7 @@ use clap::{arg, value_parser, Command};
 pub fn mozjpeg() -> Command {
     Command::new("mozjpeg")
         .alias("moz")
-        .about("Encode images into JPEG format using MozJpeg codec. (RECOMMANDED and Small)")
+        .about("Encode images into JPEG format using MozJpeg codec. (RECOMMENDED and Small)")
         .args([
             arg!(-q --quality <NUM> "Quality, values 60-80 are recommended.")
                 .value_parser(value_parser!(u8).range(1..=100))

--- a/src/cli/codecs/mozjpeg.rs
+++ b/src/cli/codecs/mozjpeg.rs
@@ -3,7 +3,7 @@ use clap::{arg, value_parser, Command};
 pub fn mozjpeg() -> Command {
     Command::new("mozjpeg")
         .alias("moz")
-        .about("Encode images into JPEG format using MozJpeg codec.")
+        .about("Encode images into JPEG format using MozJpeg codec. (RECOMMANDED and Small)")
         .args([
             arg!(-q --quality <NUM> "Quality, values 60-80 are recommended.")
                 .value_parser(value_parser!(u8).range(1..=100))

--- a/src/cli/codecs/mozjpeg.rs
+++ b/src/cli/codecs/mozjpeg.rs
@@ -3,24 +3,24 @@ use clap::{arg, value_parser, Command};
 pub fn mozjpeg() -> Command {
     Command::new("mozjpeg")
         .alias("moz")
-        .about("Encode images into JPEG format using MozJpeg codec")
+        .about("Encode images into JPEG format using MozJpeg codec.")
         .args([
-            arg!(-q --quality <NUM> "Quality, values 60-80 are recommended")
+            arg!(-q --quality <NUM> "Quality, values 60-80 are recommended.")
                 .value_parser(value_parser!(u8).range(1..=100))
                 .default_value("75"),
-            arg!(--chroma_quality <NUM> "Separate chrome quality")
+            arg!(--chroma_quality <NUM> "Separate chrome quality.")
                 .value_parser(value_parser!(u8).range(1..=100)),
-            arg!(--baseline "Set to use baseline encoding (by default is progressive)"),
-            arg!(--no_optimize_coding "Set to make files larger for no reason"),
-            arg!(--smoothing <NUM> "Use MozJPEG's smoothing")
+            arg!(--baseline "Set to use baseline encoding (by default is progressive)."),
+            arg!(--no_optimize_coding "Set to make files larger for no reason."),
+            arg!(--smoothing <NUM> "Use MozJPEG's smoothing.")
                 .value_parser(value_parser!(u8).range(1..=100)),
-            arg!(--colorspace <COLOR> "Set color space of JPEG being written")
+            arg!(--colorspace <COLOR> "Set color space of JPEG being written.")
                 .value_parser(["ycbcr", "grayscale", "rgb"])
                 .default_value("ycbcr"),
-            arg!(--multipass "Specifies whether multiple scans should be considered during trellis quantization"),
-            arg!(--subsample <PIX> "Sets chroma subsampling")
+            arg!(--multipass "Specifies whether multiple scans should be considered during trellis quantization."),
+            arg!(--subsample <PIX> "Sets chroma subsampling.")
                 .value_parser(value_parser!(u8).range(1..=4)),
-            arg!(--qtable <TABLE> "Use a specific quantization table")
+            arg!(--qtable <TABLE> "Use a specific quantization table.")
                 .value_parser([
                     "AhumadaWatsonPeterson",
                     "AnnexK",

--- a/src/cli/codecs/oxipng.rs
+++ b/src/cli/codecs/oxipng.rs
@@ -4,10 +4,10 @@ use indoc::indoc;
 pub fn oxipng() -> Command {
     Command::new("oxipng")
         .alias("oxi")
-        .about("Encode images into PNG format using OxiPNG codec")
+        .about("Encode images into PNG format using OxiPNG codec.")
         .args([
-            arg!(--interlace "Set interlace mode (progressive)"),
-            arg!(--effort <NUM> "Optimization level (0-6, or max)").long_help(indoc! {"Set the optimization level preset. The default level 2 is quite fast and provides good compression.
+            arg!(--interlace "Set interlace mode (progressive)."),
+            arg!(--effort <NUM> "Optimization level (0-6, or max)").long_help(indoc! {r#"Set the optimization level preset. The default level 2 is quite fast and provides good compression.
             Lower levels are faster, higher levels provide better compression, though with increasingly diminishing returns.
 
             0   => (1 trial, determined heuristically)
@@ -16,7 +16,7 @@ pub fn oxipng() -> Command {
             3   => (4 trials)
             4   => (4 trials)
             5   => (8 trials)
-            6   => (10 trials)"})
+            6   => (10 trials)"#})
             .value_parser(value_parser!(u8).range(0..=6))
             .default_value("2"),
         ])

--- a/src/cli/codecs/oxipng.rs
+++ b/src/cli/codecs/oxipng.rs
@@ -4,10 +4,12 @@ use indoc::indoc;
 pub fn oxipng() -> Command {
     Command::new("oxipng")
         .alias("oxi")
-        .about("Encode images into PNG format using OxiPNG codec.")
+        .about("Encode images into PNG format using OxiPNG codec. (Progressive-able)")
         .args([
             arg!(--interlace "Set interlace mode (progressive)."),
-            arg!(--effort <NUM> "Optimization level (0-6, or max)").long_help(indoc! {r#"Set the optimization level preset. The default level 2 is quite fast and provides good compression.
+            arg!(--effort <NUM> "Optimization level (0-6)").long_help(indoc! {r#"Set the optimization level preset.
+            The default level 2 is quite fast and provides good compression.
+            
             Lower levels are faster, higher levels provide better compression, though with increasingly diminishing returns.
 
             0   => (1 trial, determined heuristically)

--- a/src/cli/codecs/png.rs
+++ b/src/cli/codecs/png.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn png() -> Command {
-    Command::new("png").about("Encode images into PNG format. (Common)")
+    Command::new("png").about("Encode images into PNG format.")
 }

--- a/src/cli/codecs/png.rs
+++ b/src/cli/codecs/png.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn png() -> Command {
-    Command::new("png").about("Encode images into PNG format")
+    Command::new("png").about("Encode images into PNG format.")
 }

--- a/src/cli/codecs/png.rs
+++ b/src/cli/codecs/png.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn png() -> Command {
-    Command::new("png").about("Encode images into PNG format.")
+    Command::new("png").about("Encode images into PNG format. (Common)")
 }

--- a/src/cli/codecs/ppm.rs
+++ b/src/cli/codecs/ppm.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn ppm() -> Command {
-    Command::new("ppm").about("Encode images into PPM format")
+    Command::new("ppm").about("Encode images into PPM format.")
 }

--- a/src/cli/codecs/ppm.rs
+++ b/src/cli/codecs/ppm.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn ppm() -> Command {
-    Command::new("ppm").about("Encode images into PPM format. (Uncommon)")
+    Command::new("ppm").about("Encode images into PPM format. (Bitmapped)")
 }

--- a/src/cli/codecs/ppm.rs
+++ b/src/cli/codecs/ppm.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn ppm() -> Command {
-    Command::new("ppm").about("Encode images into PPM format.")
+    Command::new("ppm").about("Encode images into PPM format. (Uncommon)")
 }

--- a/src/cli/codecs/qoi.rs
+++ b/src/cli/codecs/qoi.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn qoi() -> Command {
-    Command::new("qoi").about("Encode images into QOI format.")
+    Command::new("qoi").about("Encode images into QOI format. (Trendy and Uncommon)")
 }

--- a/src/cli/codecs/qoi.rs
+++ b/src/cli/codecs/qoi.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn qoi() -> Command {
-    Command::new("qoi").about("Encode images into QOI format. (Trendy and Uncommon)")
+    Command::new("qoi").about("Encode images into QOI format. (Trendy and Small)")
 }

--- a/src/cli/codecs/qoi.rs
+++ b/src/cli/codecs/qoi.rs
@@ -1,5 +1,5 @@
 use clap::Command;
 
 pub fn qoi() -> Command {
-    Command::new("qoi").about("Encode images into QOI format")
+    Command::new("qoi").about("Encode images into QOI format.")
 }

--- a/src/cli/codecs/webp.rs
+++ b/src/cli/codecs/webp.rs
@@ -2,7 +2,7 @@ use clap::{arg, value_parser, Command};
 
 pub fn webp() -> Command {
     Command::new("webp")
-        .about("Encode images into WebP format. (Common and Lossless-able)")
+        .about("Encode images into WebP format. (Lossless-able)")
         .args([
             arg!(--lossless "Encode image without quality loss.").conflicts_with_all(["quality"]),
             arg!(-q --quality <NUM> "Quality, values 60-80 are recommended.")

--- a/src/cli/codecs/webp.rs
+++ b/src/cli/codecs/webp.rs
@@ -2,7 +2,7 @@ use clap::{arg, value_parser, Command};
 
 pub fn webp() -> Command {
     Command::new("webp")
-        .about("Encode images into WebP format.")
+        .about("Encode images into WebP format. (Common and Lossless-able)")
         .args([
             arg!(--lossless "Encode image without quality loss.").conflicts_with_all(["quality"]),
             arg!(-q --quality <NUM> "Quality, values 60-80 are recommended.")

--- a/src/cli/codecs/webp.rs
+++ b/src/cli/codecs/webp.rs
@@ -2,17 +2,17 @@ use clap::{arg, value_parser, Command};
 
 pub fn webp() -> Command {
     Command::new("webp")
-        .about("Encode images into WebP format")
+        .about("Encode images into WebP format.")
         .args([
-            arg!(--lossless "Encode image without quality loss").conflicts_with_all(["quality"]),
-            arg!(-q --quality <NUM> "Quality, values 60-80 are recommended")
+            arg!(--lossless "Encode image without quality loss.").conflicts_with_all(["quality"]),
+            arg!(-q --quality <NUM> "Quality, values 60-80 are recommended.")
                 .value_parser(value_parser!(u8).range(1..=100))
                 .default_value("75"),
-            arg!(--slight_loss <NUM> "Slight loss in quality for lossless encoding")
+            arg!(--slight_loss <NUM> "Slight loss in quality for lossless encoding.")
                 .value_parser(value_parser!(u8).range(0..=100))
                 .default_value("0")
                 .requires("lossless"),
-            arg!(--discrete "Discrete tone image").requires("lossless"),
-            arg!(--exact "Preserve transparent data"),
+            arg!(--discrete "Discrete tone image.").requires("lossless"),
+            arg!(--exact "Preserve transparent data."),
         ])
 }

--- a/src/cli/preprocessors/mod.rs
+++ b/src/cli/preprocessors/mod.rs
@@ -17,38 +17,38 @@ impl Preprocessors for Command {
             .next_help_heading("Preprocessors")
             .args([
                 #[cfg(feature = "resize")]
-                arg!(--resize <RESIZE> "Resize the image(s) according to the specified criteria")
-                    .long_help(indoc! {"Resize the image(s) according to the specified criteria
+                arg!(--resize <RESIZE> "Resize the image(s) according to the specified criteria.")
+                    .long_help(indoc! {r#"Resize the image(s) according to the specified criteria.
 
                     Possible values:
                     - @1.5:    Enlarge image size by this multiplier
                     - 150%:    Adjust image size by this percentage
                     - 100x100: Resize image to these dimensions
-                    - 200x_:   Adjust image dimensions while maintaining the aspect ratio based on the specified dimension"})
+                    - 200x_:   Adjust image dimensions while maintaining the aspect ratio based on the specified dimension"#})
                     .value_parser(value_parser!(ResizeValue))
                     .action(ArgAction::Append),
 
                 #[cfg(feature = "resize")]
-                arg!(--filter <FILTER> "Filter that used when resizing an image")
+                arg!(--filter <FILTER> "Filter that used when resizing an image.")
                     .value_parser(value_parser!(ResizeFilter))
                     .default_value("lanczos3")
                     .requires("resize"),
 
                 #[cfg(feature = "quantization")]
-                arg!(--quantization [QUALITY] "Enables quantization with optional quality")
-                    .long_help(indoc! {"Enables quantization with optional quality
+                arg!(--quantization [QUALITY] "Enables quantization with optional quality.")
+                    .long_help(indoc! {r#"Enables quantization with optional quality.
 
-                    If quality is not provided default 75% quality is used"})
+                    If quality is not provided, default 75 (of 100) quality is used"#})
                     .value_parser(value_parser!(u8).range(1..=100))
                     .action(ArgAction::Append)
                     .default_missing_value("75"),
 
                 #[cfg(feature = "quantization")]
                 arg!(--dithering [QUALITY] "Enables dithering with optional quality")
-                    .long_help(indoc! {"Enables dithering with optional quality
+                    .long_help(indoc! {r#"Enables dithering with optional quality
 
                     Used with --quantization flag.
-                    If quality is not provided default 75% quality is used"})
+                    If quality is not provided, default 75 (of 100) quality is used"#})
                     .value_parser(value_parser!(u8).range(1..=100))
                     .default_missing_value("75")
                     .requires("quantization")

--- a/src/cli/preprocessors/mod.rs
+++ b/src/cli/preprocessors/mod.rs
@@ -36,19 +36,19 @@ impl Preprocessors for Command {
 
                 #[cfg(feature = "quantization")]
                 arg!(--quantization [QUALITY] "Enables quantization with optional quality.")
-                    .long_help(indoc! {r#"Enables quantization with optional quality.
+                    .long_help(indoc! {r#"Enables quantization with optional quality in percentage.
 
-                    If quality is not provided, default 75 (of 100) quality is used"#})
+                    If quality is not provided, default 75 is used"#})
                     .value_parser(value_parser!(u8).range(1..=100))
                     .action(ArgAction::Append)
                     .default_missing_value("75"),
 
                 #[cfg(feature = "quantization")]
-                arg!(--dithering [QUALITY] "Enables dithering with optional quality")
-                    .long_help(indoc! {r#"Enables dithering with optional quality
+                arg!(--dithering [QUALITY] "Enables dithering with optional quality.")
+                    .long_help(indoc! {r#"Enables dithering with optional quality in percentage.
 
                     Used with --quantization flag.
-                    If quality is not provided, default 75 (of 100) quality is used"#})
+                    If quality is not provided, default 75 is used."#})
                     .value_parser(value_parser!(u8).range(1..=100))
                     .default_missing_value("75")
                     .requires("quantization")

--- a/src/cli/preprocessors/resize/filter.rs
+++ b/src/cli/preprocessors/resize/filter.rs
@@ -28,13 +28,13 @@ impl ValueEnum for ResizeFilter {
 
     fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
         Some(match self {
-            ResizeFilter::Nearest => PossibleValue::new("nearest").help("Simplest filter, for each destination pixel gets nearest source pixel"),
+            ResizeFilter::Nearest => PossibleValue::new("nearest").help("Simplest filter, for each destination pixel gets nearest source pixel."),
             ResizeFilter::Box => PossibleValue::new("box").help("Each pixel contributes equally to destination. For upscaling, like Nearest."),
-            ResizeFilter::Bilinear => PossibleValue::new("bilinear").help("Uses linear interpolation among contributing pixels for output"),
-            ResizeFilter::Hamming => PossibleValue::new("hamming").help("Provides quality akin to bicubic for downscaling, sharper than Bilinear, but not optimal for upscaling"),
-            ResizeFilter::CatmullRom => PossibleValue::new("catmull-rom").help("Employs cubic interpolation for output pixel calculation"),
-            ResizeFilter::Mitchell => PossibleValue::new("mitchell").help("Utilizes cubic interpolation for output pixel calculation"),
-            ResizeFilter::Lanczos3 => PossibleValue::new("lanczos3").help("Applies high-quality Lanczos filter for output pixel calculation"),
+            ResizeFilter::Bilinear => PossibleValue::new("bilinear").help("Uses linear interpolation among contributing pixels for output."),
+            ResizeFilter::Hamming => PossibleValue::new("hamming").help("Provides quality akin to bicubic for downscaling, sharper than Bilinear, but not optimal for upscaling."),
+            ResizeFilter::CatmullRom => PossibleValue::new("catmull-rom").help("Employs cubic interpolation for output pixel calculation."),
+            ResizeFilter::Mitchell => PossibleValue::new("mitchell").help("Utilizes cubic interpolation for output pixel calculation."),
+            ResizeFilter::Lanczos3 => PossibleValue::new("lanczos3").help("Applies high-quality Lanczos filter for output pixel calculation."),
         })
     }
 }


### PR DESCRIPTION
1. Add 'strip' in toml file for reduce program size
2. Add a period to the end of a sentence
3. Use `r#""` instead of `""` for multi-line text to avoid any accident
4. Change the quilty tips of `--dithering` and `--quantization` from `75%` to `75 (of 100)` to avoid users from misunderstanding (e.g. input `80%` instead of `80` due to the explaination and gets an error)
5. Add brief tips for each format to assist users in selecting formats

---

6. Update chapter "Supported codec list" of ReadMe and add note about it.
