### PR TITLE
chore: add version info and other infos for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # code coverage
 lcov.info
+
+# self build scrpits
+*.ps1
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,7 @@ dependencies = [
  "rgb",
  "tiff",
  "webp",
+ "winres",
  "zune-core",
  "zune-image",
  "zune-imageprocs",
@@ -1395,7 +1396,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.8.12",
  "version-compare",
 ]
 
@@ -1459,6 +1460,15 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1734,6 +1744,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winres"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+dependencies = [
+ "toml 0.5.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ homepage      = "https://lib.rs/rimage"
 include       = ["/README.md", "/Cargo.toml", "/src/**/*.rs"]
 build         = "build.rs"
 
-    [package.metadata.winres]
-    LegalCopyright  = "Copyright Vladyslav Vladinov © 2024"
-    FileDescription = "Powerful img optimization CLI tool by Rust"
+[package.metadata.winres]
+LegalCopyright  = "Copyright Vladyslav Vladinov © 2024"
+FileDescription = "Powerful img optimization CLI tool by Rust"
 
 [build-dependencies]
 winres = { version = "0.1.12", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,33 +1,64 @@
 [package]
-name = "rimage"
-version = "0.11.0-next.2"
-edition = "2021"
-description = "Optimize images natively with best-in-class codecs"
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-authors = ["Vladyslav Vladinov <vladinov.dev@gmail.com>"]
-keywords = ["image", "compression", "encoder"]
-categories = ["compression", "multimedia::images"]
-repository = "https://github.com/SalOne22/rimage"
+name          = "rimage"
+version       = "0.11.0-next.2"
+edition       = "2021"
+description   = "Optimize images natively with best-in-class codecs"
+license       = "MIT OR Apache-2.0"
+readme        = "README.md"
+authors       = ["Vladyslav Vladinov <vladinov.dev@gmail.com>"]
+keywords      = ["image", "compression", "encoder"]
+categories    = ["compression", "multimedia::images"]
+repository    = "https://github.com/SalOne22/rimage"
 documentation = "https://docs.rs/rimage"
-homepage = "https://lib.rs/rimage"
-include = ["/README.md", "/Cargo.toml", "/src/**/*.rs"]
+homepage      = "https://lib.rs/rimage"
+include       = ["/README.md", "/Cargo.toml", "/src/**/*.rs"]
+build         = "build.rs"
+
+    [package.metadata.winres]
+    LegalCopyright  = "Copyright Vladyslav Vladinov © 2024"
+    FileDescription = "Powerful img optimization CLI tool by Rust"
+
+[build-dependencies]
+winres = { version = "0.1.12", default-features = false }
 
 [profile.release]
-lto = true
+lto           = true
 codegen-units = 1
-strip = true
+strip         = true
+panic         = "abort"
 
 [[bin]]
-name = "rimage"
-path = "./src/main.rs"
+name              = "rimage"
+path              = "./src/main.rs"
 required-features = ["build-binary"]
 
 [features]
-default = ["resize", "quantization", "mozjpeg", "oxipng", "webp", "avif", "tiff", "threads", "metadata"]
+default = [
+    "resize",
+    "quantization",
+    "mozjpeg",
+    "oxipng",
+    "webp",
+    "avif",
+    "tiff",
+    "threads",
+    "metadata",
+]
 
 # Used for binary
-build-binary = ["dep:anyhow", "dep:clap", "dep:indoc", "dep:rayon", "dep:pretty_env_logger", "dep:zune-imageprocs", "dep:glob", "zune-image/default", "dep:indicatif", "dep:indicatif-log-bridge", "dep:console"]
+build-binary = [
+    "dep:anyhow",
+    "dep:clap",
+    "dep:indoc",
+    "dep:rayon",
+    "dep:pretty_env_logger",
+    "dep:zune-imageprocs",
+    "dep:glob",
+    "zune-image/default",
+    "dep:indicatif",
+    "dep:indicatif-log-bridge",
+    "dep:console",
+]
 
 # Enables utilization of threads
 threads = ["imagequant?/threads", "mozjpeg?/parallel", "oxipng?/parallel"]
@@ -48,8 +79,8 @@ webp = ["dep:webp"]
 # Enables avif codec
 avif = ["dep:ravif", "dep:libavif", "dep:rgb"]
 # Enables tiff codec
-tiff = ["dep:tiff"]
-icc = ["dep:lcms2"]
+tiff    = ["dep:tiff"]
+icc     = ["dep:lcms2"]
 console = ["dep:console"]
 
 [dependencies]
@@ -59,11 +90,18 @@ zune-image = { version = "0.5.0-rc0", default-features = false }
 fast_image_resize = { version = "3.0.4", optional = true }
 imagequant = { version = "4.3.1", default-features = false, optional = true }
 rgb = { version = "0.8.44", optional = true }
-mozjpeg = { version = "0.10.7", default-features = false, features = ["with_simd"], optional = true }
-oxipng = { version = "9.1", default-features = false, features = ["zopfli", "filetime"], optional = true }
+mozjpeg = { version = "0.10.7", default-features = false, features = [
+    "with_simd",
+], optional = true }
+oxipng = { version = "9.1", default-features = false, features = [
+    "zopfli",
+    "filetime",
+], optional = true }
 webp = { version = "0.3.0", default-features = false, optional = true }
 ravif = { version = "0.11.8", optional = true }
-libavif = { version = "0.14.0", default-features = false, features = ["codec-aom"], optional = true }
+libavif = { version = "0.14.0", default-features = false, features = [
+    "codec-aom",
+], optional = true }
 lcms2 = { version = "6.1.0", optional = true }
 tiff = { version = "0.9.1", default-features = false, optional = true }
 
@@ -73,15 +111,17 @@ clap = { version = "4.5.9", features = ["cargo", "string"], optional = true }
 indoc = { version = "2.0.5", optional = true }
 pretty_env_logger = { version = "0.5.0", optional = true }
 rayon = { version = "1.10.0", optional = true }
-zune-imageprocs = { version = "0.5.0-rc0", features = ["exif"], optional = true }
+zune-imageprocs = { version = "0.5.0-rc0", features = [
+    "exif",
+], optional = true }
 kamadak-exif = { version = "0.5.5", optional = true }
 indicatif = { version = "0.17.8", features = ["rayon"], optional = true }
-indicatif-log-bridge = { version = "0.2.2", optional = true}
+indicatif-log-bridge = { version = "0.2.2", optional = true }
 console = { version = "0.15.8", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 glob = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
-zune-core = { version = "0.5.0-rc1", features = ["std"] }
+zune-core  = { version = "0.5.0-rc1", features = ["std"] }
 zune-image = "0.5.0-rc0"

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,9 @@ fn main() {
     //     res.set_windres_path("/usr/bin/x86_64-w64-mingw32-windres");
     // }
 
+    //version  X. X. X. X
+    //         ⇑  ⇑  ⇑
+    //         48 32 16
     let mut version: u64 = 0;
     version |= 0 << 48;
     version |= 11 << 32;

--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ fn main() {
     }
 
     let mut res = winres::WindowsResource::new();
-    
+
     //version  X. X. X. X
     //         ⇑  ⇑  ⇑
     //         48 32 16

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,35 @@
+extern crate winres;
+use winres::VersionInfo;
+
+fn main() {
+    // only run if target os is windows
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
+        println!("cargo:warning={:#?}", "This build script is only for windows target, skipping...");
+        return;
+    }
+
+    let mut res = winres::WindowsResource::new();
+    // if cfg!(unix) {
+    //     // paths for X64 on archlinux
+    //     res.set_toolkit_path("/usr/x86_64-w64-mingw32/bin");
+    //     // ar tool for mingw in toolkit path
+    //     res.set_ar_path("ar");
+    //     // windres tool
+    //     res.set_windres_path("/usr/bin/x86_64-w64-mingw32-windres");
+    // }
+
+    let mut version: u64 = 0;
+    version |= 0 << 48;
+    version |= 11 << 32;
+    version |= 0 << 16;
+    version |= 2;
+
+    res.set_version_info(VersionInfo::FILEVERSION, version)
+        .set_version_info(VersionInfo::PRODUCTVERSION, version);
+
+    if let Err(e) = res.compile() {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+    // }
+}

--- a/build.rs
+++ b/build.rs
@@ -12,15 +12,7 @@ fn main() {
     }
 
     let mut res = winres::WindowsResource::new();
-    // if cfg!(unix) {
-    //     // paths for X64 on archlinux
-    //     res.set_toolkit_path("/usr/x86_64-w64-mingw32/bin");
-    //     // ar tool for mingw in toolkit path
-    //     res.set_ar_path("ar");
-    //     // windres tool
-    //     res.set_windres_path("/usr/bin/x86_64-w64-mingw32-windres");
-    // }
-
+    
     //version  X. X. X. X
     //         ⇑  ⇑  ⇑
     //         48 32 16
@@ -37,5 +29,4 @@ fn main() {
         eprintln!("{}", e);
         std::process::exit(1);
     }
-    // }
 }

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,10 @@ use winres::VersionInfo;
 fn main() {
     // only run if target os is windows
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
-        println!("cargo:warning={:#?}", "This build script is only for windows target, skipping...");
+        println!(
+            "cargo:warning={:#?}",
+            "This build script is only for windows target, skipping..."
+        );
         return;
     }
 

--- a/build.rs
+++ b/build.rs
@@ -45,17 +45,16 @@ fn main() {
             << 16
     };
 
-    let file_version = version | 0 as u64;
     let product_version = version | {
         let temp = env::var("CARGO_PKG_VERSION_PRE").unwrap();
-        if temp == String::from("") {
-            0 as u64
+        if temp == *"" {
+            0_u64
         } else {
-            temp.parse::<u64>().unwrap_or(0 as u64)
+            temp.parse::<u64>().unwrap_or(0_u64)
         }
     };
 
-    res.set_version_info(VersionInfo::FILEVERSION, file_version)
+    res.set_version_info(VersionInfo::FILEVERSION, version)
         .set_version_info(VersionInfo::PRODUCTVERSION, product_version);
 
     if let Err(e) = res.compile() {

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+[env]
+# Because rust doesn't support it in cargo.toml => package.version, so it has to be define here to avoid any accident
+CARGO_PKG_VERSION_PRE = { value = "2", force = true, relative = true }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -51,7 +51,7 @@ pub(crate) fn create_test_image_animated(
         frames.push(Frame::new(channels))
     });
 
-    let image = Image::new_frames(frames, BitDepth::Eight, width, height, colorspace);
+    
 
-    image
+    Image::new_frames(frames, BitDepth::Eight, width, height, colorspace)
 }


### PR DESCRIPTION
Add some info for windows such as FILEVERSION, PRODUCTVERSION, LegalCopyright, FileDescription... PLEASE note that gnu target doesn't support to add these infos to exe.

And, if it is necessary to add an icon, it is also very convenient using the package winres.

Besides, formatted cargo.toml using rust-analyzer with vscode.