### PR TITLE
chore(build): Add support for GNU target, static linking build on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,5 +7,19 @@ linker = 'aarch64-linux-gnu-gcc'
 [target.aarch64-unknown-linux-musl]
 linker = 'aarch64-linux-musl-gcc'
 
+[target.x86_64-pc-windows-gnu]
+linker = 'gcc'
+rustflags = [
+    "-C", "target-feature=+crt-static",
+    "-C", "link-arg=-static-libgcc",
+    "-C", "link-arg=-static-libstdc++",
+]
+
+[env]
+CMAKE_GENERATOR_x86_64-pc-windows-gnu = "MinGW Makefiles"
+CC_x86_64-pc-windows-gnu = "gcc"
+CXX_x86_64-pc-windows-gnu = "g++"
+AR_x86_64-pc-windows-gnu = "ar"
+
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## brief
Add supprot for GNU target static linking build on windows, use the following commandline to build.
`cargo b -r --target=x86_64-pc-windows-gnu --all-features`

## benefit
Gnu target always builds with static link, this would allow the process work on pc even the user doesn't install msvc runtime frameworks.

## lack
temporarily did not find yet