### PR TITLE
add icc to the build-binary feature to fix compilation errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ build-binary = [
     "dep:console",
     "dep:regex",
     "dep:little_exif",
+    "icc"
 ]
 
 # Enables utilization of threads


### PR DESCRIPTION
When I was trying to build the CLI, I was getting the following errors: 
```bash
error[E0432]: unresolved import `rimage::operations::icc`
  --> src/main.rs:21:25
   |
21 | use rimage::operations::icc::ApplySRGB;
   |                         ^^^ could not find `icc` in `operations`
   |
note: found an item that was configured out
  --> /home/lucas/Desktop/rimage/src/operations/mod.rs:12:9
   |
11 | #[cfg(feature = "icc")]
   |       --------------- the item is gated behind the `icc` feature
12 | pub mod icc;
   |         ^^^
```

Enabling the `icc`, when `build-binary` is also enabled, fixed the error.