### PR TITLE
Improve logic and design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lcov.info
 *.log
 *.diff
 *.bat
+CLAUDE.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ homepage      = "https://lib.rs/rimage"
 include       = ["/README.md", "/Cargo.toml", "/src/**/*.rs"]
 build         = "build.rs"
 
-[package.metadata.winres]
-LegalCopyright  = "Copyright Vladyslav Vladinov © 2024-2026"
-FileDescription = "Powerful img optimization CLI tool by Rust"
+    [package.metadata.winres]
+    LegalCopyright  = "Copyright Vladyslav Vladinov © 2024-2026"
+    FileDescription = "Powerful img optimization CLI tool by Rust"
 
 [build-dependencies]
 winres = { version = "0.1.12", default-features = false }
@@ -96,7 +96,9 @@ console = ["dep:console"]
 [dependencies]
 zune-core = "0.5"
 log = "0.4"
-zune-image = { version = "0.5.0-rc0", default-features = false, features = ["simd"] }
+zune-image = { version = "0.5.0", default-features = false, features = [
+    "simd",
+] }
 fast_image_resize = { version = "5.4", optional = true }
 imagequant = { version = "4.4", default-features = false, optional = true }
 rgb = { version = "0.8", optional = true }
@@ -113,7 +115,9 @@ libavif = { version = "0.14.0", default-features = false, features = [
     "codec-aom",
 ], optional = true }
 lcms2 = { version = "6.1", optional = true }
-tiff = { version = "0.10.3", default-features = false, features = ["lzw"], optional = true }
+tiff = { version = "0.10.3", default-features = false, features = [
+    "lzw",
+], optional = true }
 
 # cli
 anyhow = { version = "1.0", optional = true }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.12.x  | :white_check_mark: |
 | 0.11.x  | :white_check_mark: |
 | 0.10.x  | :white_check_mark: |
 | 0.9.x   | :white_check_mark: |

--- a/src/codecs/mozjpeg/encoder/mod.rs
+++ b/src/codecs/mozjpeg/encoder/mod.rs
@@ -201,12 +201,6 @@ impl EncoderTrait for MozJpegEncoder {
 
             #[cfg(feature = "metadata")]
             {
-                // write exif data
-                if let Some(_metadata) = &image.metadata().exif() {
-                    log::warn!("Writing exif data is not supported");
-                }
-
-                // write icc data
                 if let Some(metadata) = &image.metadata().icc_chunk() {
                     comp.write_icc_profile(metadata);
                 }

--- a/src/codecs/oxipng/encoder/mod.rs
+++ b/src/codecs/oxipng/encoder/mod.rs
@@ -95,12 +95,6 @@ impl EncoderTrait for OxiPngEncoder {
 
         #[cfg(feature = "metadata")]
         {
-            // write exif data
-            if let Some(_metadata) = &image.metadata().exif() {
-                log::warn!("Writing exif data is not supported");
-            }
-
-            // write icc data
             if let Some(icc) = &image.metadata().icc_chunk() {
                 img.add_icc_profile(icc);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,21 +188,32 @@ fn main() {
     LogWrapper::new(multi.clone(), logger).try_init().unwrap();
     log::set_max_level(level);
 
-    let matches = cli().get_matches_from(
-        #[cfg(not(windows))]
-        {
-            std::env::args()
-        },
-        #[cfg(windows)]
-        {
-            std::env::args().map(|arg| {
-                arg.replace("\\", "/")
-                    .replace("//", "/")
-                    .trim_matches(['\\', '/', '\n', '\r', '"', '\'', ' ', '\t'])
-                    .to_string()
-            })
-        },
-    );
+    let current_dir = std::env::current_dir().unwrap_or_default();
+    let matches = cli().get_matches_from({
+        std::env::args().map(|arg| {
+            let mut checked_arg = arg
+                .replace('\\', "/")
+                .replace("//", "/")
+                .trim_matches(['\n', '\r', '"', '\'', ' ', '\t'])
+                .to_string();
+
+            if checked_arg.starts_with("./") {
+                checked_arg = current_dir
+                    .join(&checked_arg[2..])
+                    .to_string_lossy()
+                    .into_owned();
+            }
+
+            #[cfg(not(windows))]
+            {
+                checked_arg
+            }
+            #[cfg(windows)]
+            {
+                checked_arg.replace("/", "\\")
+            }
+        })
+    });
 
     let results: Arc<Mutex<Vec<Result>>> = Arc::new(Mutex::new(vec![]));
     let metadata: Arc<Mutex<Option<Metadata>>> = Arc::new(Mutex::new(None));

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,20 @@ struct Result {
     output_size: u64,
 }
 
+struct ProcessingState {
+    results: Vec<Result>,
+    metadata: Option<Metadata>,
+}
+
+impl ProcessingState {
+    fn new() -> Self {
+        Self {
+            results: vec![],
+            metadata: None,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct Metadata {
     #[serde(rename = "inputSize")]
@@ -215,8 +229,8 @@ fn main() {
         })
     });
 
-    let results: Arc<Mutex<Vec<Result>>> = Arc::new(Mutex::new(vec![]));
-    let metadata: Arc<Mutex<Option<Metadata>>> = Arc::new(Mutex::new(None));
+    let state: Arc<Mutex<ProcessingState>> =
+        Arc::new(Mutex::new(ProcessingState::new()));
 
     match matches.subcommand() {
         Some((subcommand, matches)) => {
@@ -388,19 +402,18 @@ fn main() {
                     let processed_at = get_current_timestamp();
                     let output_created = get_current_timestamp();
 
-                    let mut results = results.lock().unwrap();
-                    let mut metadata = metadata.lock().unwrap();
+                    let mut state = state.lock().unwrap();
 
                     let absolute_input_path = fs::canonicalize(&input).unwrap();
                     let absolute_output_path = fs::canonicalize(&output).unwrap();
 
-                    results.push(Result {
+                    state.results.push(Result {
                         output,
                         input_size,
                         output_size,
                     });
 
-                    let metadata = metadata.get_or_insert(Metadata {
+                    let metadata = state.metadata.get_or_insert(Metadata {
                         input_size: 0,
                         output_size: 0,
                         total_images: 0,
@@ -443,11 +456,10 @@ fn main() {
                     pb.finish_and_clear();
                 });
 
-            let mut results = results.lock().unwrap();
-            let mut metadata = metadata.lock().unwrap();
+            let mut state = state.lock().unwrap();
 
             // Update final metadata calculations
-            if let Some(ref mut meta) = metadata.as_mut() {
+            if let Some(ref mut meta) = state.metadata.as_mut() {
                 meta.compression_ratio = if meta.input_size > 0 {
                     meta.output_size as f64 / meta.input_size as f64
                 } else {
@@ -455,9 +467,10 @@ fn main() {
                 };
             }
 
-            results.sort_by(|a, b| b.output_size.cmp(&a.output_size));
+            state.results.sort_by(|a, b| b.output_size.cmp(&a.output_size));
 
-            let path_width = results
+            let path_width = state
+                .results
                 .iter()
                 .map(|r| r.output.display().to_string().len())
                 .max()
@@ -466,7 +479,7 @@ fn main() {
             if !quiet {
                 let term = Term::stdout();
 
-                if results.len() > 1 {
+                if state.results.len() > 1 {
                     term.write_line(&format!(
                         "{:<path_width$} {}",
                         style("File").bold(),
@@ -474,7 +487,7 @@ fn main() {
                     ))
                     .unwrap();
 
-                    for result in results.iter() {
+                    for result in state.results.iter() {
                         let difference =
                             (result.output_size as f64 / result.input_size as f64) * 100.0;
 
@@ -493,8 +506,8 @@ fn main() {
                     }
                 }
 
-                let total_input_size = results.iter().map(|r| r.input_size).sum::<u64>();
-                let total_output_size = results.iter().map(|r| r.output_size).sum::<u64>();
+                let total_input_size = state.results.iter().map(|r| r.input_size).sum::<u64>();
+                let total_output_size = state.results.iter().map(|r| r.output_size).sum::<u64>();
 
                 let difference = (total_output_size as f64 / total_input_size as f64) * 100.0;
 
@@ -511,7 +524,7 @@ fn main() {
                 .unwrap();
             }
 
-            if output_metadata && let Some(metadata) = metadata.as_ref() {
+            if output_metadata && let Some(metadata) = state.metadata.as_ref() {
                 let json = serde_json::to_string_pretty(metadata).unwrap();
                 fs::write(metadata_path, json).unwrap();
             }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -45,9 +45,11 @@ pub(crate) fn create_test_image_animated(
     let mut frames = vec![];
 
     let channel_length = width * height;
+    let num_components = colorspace.num_components();
 
     (0..=5).for_each(|_| {
-        let channels = vec![Channel::new_with_bit_type(channel_length, BitType::U8); 3];
+        let channels =
+            vec![Channel::new_with_bit_type(channel_length, BitType::U8); num_components];
         frames.push(Frame::new(channels))
     });
 


### PR DESCRIPTION
- test_utils: animated images now use colorspace.num_components() for correct channel count instead of hardcoded 3 channels.
  Previously RGBA animated test images were missing the alpha channel.
- mozjpeg/oxipng encoders: removed misleading "EXIF not supported" log warnings since EXIF is handled externally by main.rs.
- main.rs: merged dual Arc<Mutex<...>> (results + metadata) into single ProcessingState struct with one mutex. Eliminates the fragile two-lock pattern that could deadlock if lock order ever changed.

④