### PR TITLE
Improve parameter handling robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lcov.info
 *.log
 *.diff
 *.bat
+CLAUDE.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ homepage      = "https://lib.rs/rimage"
 include       = ["/README.md", "/Cargo.toml", "/src/**/*.rs"]
 build         = "build.rs"
 
-[package.metadata.winres]
-LegalCopyright  = "Copyright Vladyslav Vladinov © 2024-2026"
-FileDescription = "Powerful img optimization CLI tool by Rust"
+    [package.metadata.winres]
+    LegalCopyright  = "Copyright Vladyslav Vladinov © 2024-2026"
+    FileDescription = "Powerful img optimization CLI tool by Rust"
 
 [build-dependencies]
 winres = { version = "0.1.12", default-features = false }
@@ -96,7 +96,9 @@ console = ["dep:console"]
 [dependencies]
 zune-core = "0.5"
 log = "0.4"
-zune-image = { version = "0.5.0-rc0", default-features = false, features = ["simd"] }
+zune-image = { version = "0.5.0", default-features = false, features = [
+    "simd",
+] }
 fast_image_resize = { version = "5.4", optional = true }
 imagequant = { version = "4.4", default-features = false, optional = true }
 rgb = { version = "0.8", optional = true }
@@ -113,7 +115,9 @@ libavif = { version = "0.14.0", default-features = false, features = [
     "codec-aom",
 ], optional = true }
 lcms2 = { version = "6.1", optional = true }
-tiff = { version = "0.10.3", default-features = false, features = ["lzw"], optional = true }
+tiff = { version = "0.10.3", default-features = false, features = [
+    "lzw",
+], optional = true }
 
 # cli
 anyhow = { version = "1.0", optional = true }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.12.x  | :white_check_mark: |
 | 0.11.x  | :white_check_mark: |
 | 0.10.x  | :white_check_mark: |
 | 0.9.x   | :white_check_mark: |

--- a/src/cli/codecs/mozjpeg.rs
+++ b/src/cli/codecs/mozjpeg.rs
@@ -10,7 +10,7 @@ pub fn mozjpeg() -> Command {
             arg!(-q --quality <NUM> "Quality, values 60-80 are recommended.")
                 .value_parser(value_parser!(u8).range(1..=100))
                 .default_value("75"),
-            arg!(--chroma_quality <NUM> "Separate chrome quality.")
+            arg!(--chroma_quality <NUM> "Separate chroma quality.")
                 .value_parser(value_parser!(u8).range(1..=100)),
             arg!(--baseline "Set to use baseline encoding (by default is progressive)."),
             arg!(--no_optimize_coding "Set to make files larger for no reason."),

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -38,7 +38,7 @@ impl CommonArgs for Command {
 
                 Usage of multiple threads can speed up the execution of tasks, especially on multi-core processors.
                 By default, the number of available threads is utilized."#})
-                .value_parser(value_parser!(u8).range(1..=threads::num_threads() as i64)),
+                .value_parser(value_parser!(usize).range(1..=threads::num_threads())),
             arg!(-x --strip "Strip metadata when encoding images (where supported)")
                 .action(ArgAction::SetTrue),
             arg!(--"no-progress" "Disables progress bar.")

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -281,7 +281,7 @@ pub fn encoder(name: &str, matches: &ArgMatches) -> Result<AvailableEncoders, Im
             use mozjpeg::qtable;
             use rimage::codecs::mozjpeg::MozJpegOptions;
 
-            let quality = *matches.get_one::<u8>("quality").unwrap() as f32;
+            let quality = matches.get_one::<u8>("quality").copied().unwrap_or(75) as f32;
             let chroma_quality = matches
                 .get_one::<u8>("chroma_quality")
                 .map(|q| *q as f32)
@@ -295,7 +295,11 @@ pub fn encoder(name: &str, matches: &ArgMatches) -> Result<AvailableEncoders, Im
                     .get_one::<u8>("smoothing")
                     .copied()
                     .unwrap_or_default(),
-                color_space: match matches.get_one::<String>("colorspace").unwrap().as_str() {
+                color_space: match matches
+                    .get_one::<String>("colorspace")
+                    .map(|s| s.as_str())
+                    .unwrap_or("ycbcr")
+                {
                     "ycbcr" => mozjpeg::ColorSpace::JCS_YCbCr,
                     "rgb" => mozjpeg::ColorSpace::JCS_EXT_RGB,
                     "grayscale" => mozjpeg::ColorSpace::JCS_GRAYSCALE,
@@ -377,19 +381,35 @@ pub fn encoder(name: &str, matches: &ArgMatches) -> Result<AvailableEncoders, Im
             use rimage::codecs::avif::AvifOptions;
 
             let options = AvifOptions {
-                quality: *matches.get_one::<u8>("quality").unwrap() as f32,
+                quality: matches.get_one::<u8>("quality").copied().unwrap_or(50) as f32,
                 alpha_quality: matches.get_one::<u8>("alpha_quality").map(|q| *q as f32),
-                speed: *matches.get_one::<u8>("speed").unwrap(),
-                color_space: match matches.get_one::<String>("colorspace").unwrap().as_str() {
+                speed: matches.get_one::<u8>("speed").copied().unwrap_or(6),
+                color_space: match matches
+                    .get_one::<String>("colorspace")
+                    .map(|s| s.as_str())
+                    .unwrap_or("ycbcr")
+                {
                     "ycbcr" => ravif::ColorModel::YCbCr,
                     "rgb" => ravif::ColorModel::RGB,
-                    _ => unreachable!(),
+                    cs => {
+                        return Err(ImageErrors::GenericString(format!(
+                            "Unsupported avif colorspace: {cs}",
+                        )));
+                    }
                 },
-                alpha_color_mode: match matches.get_one::<String>("alpha_mode").unwrap().as_str() {
+                alpha_color_mode: match matches
+                    .get_one::<String>("alpha_mode")
+                    .map(|s| s.as_str())
+                    .unwrap_or("UnassociatedClean")
+                {
                     "UnassociatedDirty" => ravif::AlphaColorMode::UnassociatedDirty,
                     "UnassociatedClean" => ravif::AlphaColorMode::UnassociatedClean,
                     "Premultiplied" => ravif::AlphaColorMode::Premultiplied,
-                    _ => unreachable!(),
+                    mode => {
+                        return Err(ImageErrors::GenericString(format!(
+                            "Unsupported avif alpha mode: {mode}",
+                        )));
+                    }
                 },
             };
 
@@ -403,9 +423,10 @@ pub fn encoder(name: &str, matches: &ArgMatches) -> Result<AvailableEncoders, Im
 
             let mut options = WebPOptions::new().unwrap();
 
-            options.quality = *matches.get_one::<u8>("quality").unwrap() as f32;
+            options.quality = matches.get_one::<u8>("quality").copied().unwrap_or(75) as f32;
             options.lossless = matches.get_flag("lossless") as i32;
-            options.near_lossless = 100 - *matches.get_one::<u8>("slight_loss").unwrap() as i32;
+            options.near_lossless =
+                100 - matches.get_one::<u8>("slight_loss").copied().unwrap_or(0) as i32;
             options.exact = matches.get_flag("exact") as i32;
 
             Ok(AvailableEncoders::Webp(Box::new(

--- a/src/cli/preprocessors/resize/value.rs
+++ b/src/cli/preprocessors/resize/value.rs
@@ -1,5 +1,12 @@
+use std::sync::LazyLock;
+
 use anyhow::anyhow;
 use regex::Regex;
+
+static WIDTH_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?P<width>\d+)").unwrap());
+static HEIGHT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?P<height>\d+)").unwrap());
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ResizeValue {
@@ -67,16 +74,14 @@ impl std::str::FromStr for ResizeValue {
             s if s.ends_with('%') => Ok(Self::Percentage(s[..s.len() - 1].parse()?)),
             s if s.contains('w') && s.contains('h') => Err(anyhow!("Invalid resize value")),
             s if s.contains('w') => {
-                let re = Regex::new(r"(?P<width>\d+)").unwrap();
-                let Some(cap) = re.captures(&s) else {
+                let Some(cap) = WIDTH_RE.captures(&s) else {
                     return Err(anyhow!("Invalid resize value"));
                 };
 
                 Ok(Self::Dimensions(Some(cap["width"].parse()?), None))
             }
             s if s.contains('h') => {
-                let re = Regex::new(r"(?P<height>\d+)").unwrap();
-                let Some(cap) = re.captures(&s) else {
+                let Some(cap) = HEIGHT_RE.captures(&s) else {
                     return Err(anyhow!("Invalid resize value"));
                 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,21 +188,32 @@ fn main() {
     LogWrapper::new(multi.clone(), logger).try_init().unwrap();
     log::set_max_level(level);
 
-    let matches = cli().get_matches_from(
-        #[cfg(not(windows))]
-        {
-            std::env::args()
-        },
-        #[cfg(windows)]
-        {
-            std::env::args().map(|arg| {
-                arg.replace("\\", "/")
-                    .replace("//", "/")
-                    .trim_matches(['\\', '/', '\n', '\r', '"', '\'', ' ', '\t'])
-                    .to_string()
-            })
-        },
-    );
+    let current_dir = std::env::current_dir().unwrap_or_default();
+    let matches = cli().get_matches_from({
+        std::env::args().map(|arg| {
+            let mut checked_arg = arg
+                .replace('\\', "/")
+                .replace("//", "/")
+                .trim_matches(['\n', '\r', '"', '\'', ' ', '\t'])
+                .to_string();
+
+            if checked_arg.starts_with("./") {
+                checked_arg = current_dir
+                    .join(&checked_arg[2..])
+                    .to_string_lossy()
+                    .into_owned();
+            }
+
+            #[cfg(not(windows))]
+            {
+                checked_arg
+            }
+            #[cfg(windows)]
+            {
+                checked_arg.replace("/", "\\")
+            }
+        })
+    });
 
     let results: Arc<Mutex<Vec<Result>>> = Arc::new(Mutex::new(vec![]));
     let metadata: Arc<Mutex<Option<Metadata>>> = Arc::new(Mutex::new(None));

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,9 +220,9 @@ fn main() {
 
     match matches.subcommand() {
         Some((subcommand, matches)) => {
-            if let Some(threads) = matches.get_one::<u8>("threads") {
+            if let Some(threads) = matches.get_one::<usize>("threads") {
                 rayon::ThreadPoolBuilder::new()
-                    .num_threads(*threads as usize)
+                    .num_threads(*threads)
                     .build_global()
                     .unwrap();
             }


### PR DESCRIPTION
- Thread count changed from u8 to usize, removing the 255-thread ceiling and the lossy i64 cast in the clap range validator.
- pipeline encoder fn: replaced unwrap() calls on clap get_one with unwrap_or fallbacks for quality, colorspace, alpha_mode, speed, and slight_loss parameters. Makes the encoder function safe to call without CLI defaults.
- ResizeValue from_str: compiled regex patterns are now stored in LazyLock statics rather than recompiled on every parse.
- Fixed typo "chrome quality" -> "chroma quality" in mozjpeg CLI help text.

⑥