### PR TITLE
Code quality improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lcov.info
 *.log
 *.diff
 *.bat
+CLAUDE.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,5 +140,5 @@ serde_json = { version = "1.0", optional = true }
 glob = { version = "0.3", optional = true }
 
 [dev-dependencies]
-zune-core  = { version = "0.5.0", features = ["std"] }
-zune-image = "0.5.0-rc0"
+zune-core  = { version = "0.5", features = ["std"] }
+zune-image = { version = "0.5.0", default-features = false, features = ["jpeg"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ homepage      = "https://lib.rs/rimage"
 include       = ["/README.md", "/Cargo.toml", "/src/**/*.rs"]
 build         = "build.rs"
 
-[package.metadata.winres]
-LegalCopyright  = "Copyright Vladyslav Vladinov © 2024-2026"
-FileDescription = "Powerful img optimization CLI tool by Rust"
+    [package.metadata.winres]
+    LegalCopyright  = "Copyright Vladyslav Vladinov © 2024-2026"
+    FileDescription = "Powerful img optimization CLI tool by Rust"
 
 [build-dependencies]
 winres = { version = "0.1.12", default-features = false }
@@ -96,7 +96,9 @@ console = ["dep:console"]
 [dependencies]
 zune-core = "0.5"
 log = "0.4"
-zune-image = { version = "0.5.0-rc0", default-features = false, features = ["simd"] }
+zune-image = { version = "0.5.0", default-features = false, features = [
+    "simd",
+] }
 fast_image_resize = { version = "5.4", optional = true }
 imagequant = { version = "4.4", default-features = false, optional = true }
 rgb = { version = "0.8", optional = true }
@@ -113,7 +115,9 @@ libavif = { version = "0.14.0", default-features = false, features = [
     "codec-aom",
 ], optional = true }
 lcms2 = { version = "6.1", optional = true }
-tiff = { version = "0.10.3", default-features = false, features = ["lzw"], optional = true }
+tiff = { version = "0.10.3", default-features = false, features = [
+    "lzw",
+], optional = true }
 
 # cli
 anyhow = { version = "1.0", optional = true }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.12.x  | :white_check_mark: |
 | 0.11.x  | :white_check_mark: |
 | 0.10.x  | :white_check_mark: |
 | 0.9.x   | :white_check_mark: |

--- a/src/cli/preprocessors/mod.rs
+++ b/src/cli/preprocessors/mod.rs
@@ -60,7 +60,7 @@ impl Preprocessors for Command {
                 arg!(--upscale "Upscale the image(s) when resizing.")
                     .long_help(indoc! {r#"Upscale the image(s) when resizing.
 
-                    This is useful when you want to reduce the size of the image when it is larger than the specified size.
+                    This is useful when you want to increase the size of the image when it is smaller than the specified size.
                     It is recommended to use this option with --resize"#})
                     .default_value("true")
                     .action(ArgAction::SetTrue)
@@ -70,7 +70,7 @@ impl Preprocessors for Command {
                 arg!(--"no-upscale" "Disable upscaling when resizing.")
                     .long_help(indoc! {r#"Disable upscaling when resizing.
 
-                    This is useful when you don't want to reduce the size of the image when it is larger than the specified size.
+                    This is useful when you don't want to increase the size of the image when it is smaller than the specified size.
                     It is recommended to use this option with --resize"#})
                     .action(ArgAction::SetTrue)
                     .requires("resize"),

--- a/src/codecs/mozjpeg/encoder/mod.rs
+++ b/src/codecs/mozjpeg/encoder/mod.rs
@@ -127,20 +127,15 @@ impl EncoderTrait for MozJpegEncoder {
             comp.set_size(width, height);
 
             // When using custom quantization tables with very high quality settings (>= 85),
-            // DCT coefficients can overflow. Instead of reducing quality, we apply smoothing
-            // to normalize the data and prevent coefficient overflow.
+            // DCT coefficients can overflow. To prevent this, we apply a minimum smoothing
+            // factor of 10, which may slightly reduce sharpness but prevents encode failures.
             let has_custom_qtables = luma_qtable.is_some() || chroma_qtable.is_some();
             let safe_smoothing = if has_custom_qtables && self.options.quality >= 85.0 {
-                // Apply moderate smoothing to prevent DCT coefficient overflow
-                // This helps normalize extreme pixel values without reducing quality
-                let applied_smoothing = if self.options.smoothing >= 10 {
-                    self.options.smoothing
-                } else {
-                    10 // Minimum smoothing required to prevent DCT overflow
-                };
+                let applied_smoothing = self.options.smoothing.max(10);
                 log::warn!(
                     "High quality ({}) with custom quantization tables detected. \
-                     Applying smoothing ({}) to prevent DCT coefficient overflow.",
+                     Applying smoothing ({}) to prevent DCT coefficient overflow. \
+                     This may slightly reduce sharpness.",
                     self.options.quality,
                     applied_smoothing
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,21 +188,32 @@ fn main() {
     LogWrapper::new(multi.clone(), logger).try_init().unwrap();
     log::set_max_level(level);
 
-    let matches = cli().get_matches_from(
-        #[cfg(not(windows))]
-        {
-            std::env::args()
-        },
-        #[cfg(windows)]
-        {
-            std::env::args().map(|arg| {
-                arg.replace("\\", "/")
-                    .replace("//", "/")
-                    .trim_matches(['\\', '/', '\n', '\r', '"', '\'', ' ', '\t'])
-                    .to_string()
-            })
-        },
-    );
+    let current_dir = std::env::current_dir().unwrap_or_default();
+    let matches = cli().get_matches_from({
+        std::env::args().map(|arg| {
+            let mut checked_arg = arg
+                .replace('\\', "/")
+                .replace("//", "/")
+                .trim_matches(['\n', '\r', '"', '\'', ' ', '\t'])
+                .to_string();
+
+            if checked_arg.starts_with("./") {
+                checked_arg = current_dir
+                    .join(&checked_arg[2..])
+                    .to_string_lossy()
+                    .into_owned();
+            }
+
+            #[cfg(not(windows))]
+            {
+                checked_arg
+            }
+            #[cfg(windows)]
+            {
+                checked_arg.replace("/", "\\")
+            }
+        })
+    });
 
     let results: Arc<Mutex<Vec<Result>>> = Arc::new(Mutex::new(vec![]));
     let metadata: Arc<Mutex<Option<Metadata>>> = Arc::new(Mutex::new(None));

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,8 @@ fn normalize_arg(raw: String, current_dir: &Path) -> String {
 
     // Skip known subcommands
     let subcommands = [
-        "avif", "farbfeld", "jpeg", "jpegxl", "mozjpeg", "oxipng", "png", "ppm", "qoi", "tiff", "webp",
+        "avif", "farbfeld", "jpeg", "jpegxl", "mozjpeg", "oxipng", "png", "ppm", "qoi", "tiff",
+        "webp",
     ];
     if subcommands.contains(&arg.as_str()) {
         return arg;
@@ -306,10 +307,8 @@ fn main() {
     log::set_max_level(level);
 
     let current_dir = std::env::current_dir().unwrap_or_default();
-    let matches = cli().get_matches_from({
-        std::env::args()
-            .map(|arg| normalize_arg(arg, &current_dir))
-    });
+    let matches =
+        cli().get_matches_from({ std::env::args().map(|arg| normalize_arg(arg, &current_dir)) });
 
     let results: Arc<Mutex<Vec<Result>>> = Arc::new(Mutex::new(vec![]));
     let metadata: Arc<Mutex<Option<Metadata>>> = Arc::new(Mutex::new(None));
@@ -456,7 +455,8 @@ fn main() {
                                 .unwrap_or("backup"),
                             input.extension().and_then(|s| s.to_str()).unwrap_or("bak"),
                         );
-                        handle_error!(input, fs::rename(&input, backup_name));
+                        let backup_path = input.with_file_name(&backup_name);
+                        handle_error!(input, fs::rename(&input, backup_path));
                     }
 
                     if let Some(parent) = output.parent() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,24 @@ fn normalize_arg(raw: String, current_dir: &Path) -> String {
         return arg;
     }
 
+    // Skip flags and options
+    if arg.starts_with('-') {
+        return arg;
+    }
+
+    // Skip known subcommands
+    let subcommands = [
+        "avif", "farbfeld", "jpeg", "jpegxl", "mozjpeg", "oxipng", "png", "ppm", "qoi", "tiff", "webp",
+    ];
+    if subcommands.contains(&arg.as_str()) {
+        return arg;
+    }
+
+    // Skip numbers (e.g., quality, resize values)
+    if arg.parse::<f64>().is_ok() {
+        return arg;
+    }
+
     // Expand ~ to home directory before path normalization
     let arg = expand_tilde(&arg);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn get_file_modified_time(path: &Path) -> Option<u64> {
 fn get_current_timestamp() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or_default()
         .as_secs()
 }
 
@@ -171,6 +171,105 @@ fn colorspace_to_string(colorspace: &ColorSpace) -> String {
     }
 }
 
+/// Normalize a CLI argument into a canonical path string suitable for clap parsing.
+///
+/// Handles:
+/// - Trimming surrounding quotes and whitespace
+/// - Expanding `~` to the home directory
+/// - Resolving relative paths (`.`, `..`) against the current directory
+/// - Normalizing path separators per-platform while preserving UNC prefixes
+/// - Canonicalizing existing paths (resolves symlinks and `..`)
+fn normalize_arg(raw: String, current_dir: &Path) -> String {
+    let arg = raw
+        .trim_matches(['\n', '\r', '"', '\'', ' ', '\t'])
+        .to_string();
+
+    if arg.is_empty() {
+        return arg;
+    }
+
+    // Expand ~ to home directory before path normalization
+    let arg = expand_tilde(&arg);
+
+    let path = PathBuf::from(&arg);
+
+    // Use Path components to detect absolute paths and UNC prefixes
+    // rather than fragile string matching
+    let is_absolute = path.is_absolute()
+        || path
+            .components()
+            .next()
+            .is_some_and(|c| matches!(c, std::path::Component::Prefix(_)));
+
+    // Resolve relative paths against current_dir
+    let path = if is_absolute {
+        path
+    } else {
+        current_dir.join(&path)
+    };
+
+    // Canonicalize existing paths (resolves .., symlinks, and normalizes case).
+    // For paths that don't exist yet (e.g. output directories), keep the joined path.
+    let path = path.canonicalize().unwrap_or(path);
+
+    #[cfg(not(windows))]
+    {
+        path.to_string_lossy().into_owned()
+    }
+    #[cfg(windows)]
+    {
+        // On Windows, preserve canonicalized UNC and verbatim prefixes as-is.
+        // For regular paths, ensure backslash separators.
+        let uses_unc_or_verbatim = path
+            .components()
+            .next()
+            .is_some_and(|c| matches!(c, std::path::Component::Prefix(p) if matches!(p.kind(), std::path::Prefix::VerbatimUNC(..) | std::path::Prefix::UNC(..) | std::path::Prefix::Verbatim(_))));
+
+        if uses_unc_or_verbatim {
+            path.to_string_lossy().into_owned()
+        } else {
+            path.to_string_lossy().replace('/', "\\")
+        }
+    }
+}
+
+/// Expand a leading `~` to the user's home directory.
+///
+/// On Unix: uses `HOME` env var.
+/// On Windows: uses `USERPROFILE` env var.
+/// Falls back to the original string if the env var is unset.
+fn expand_tilde(arg: &str) -> String {
+    if !arg.starts_with('~') {
+        return arg.to_string();
+    }
+
+    #[cfg(windows)]
+    let home_var = "USERPROFILE";
+    #[cfg(not(windows))]
+    let home_var = "HOME";
+
+    let home_dir = match std::env::var(home_var) {
+        Ok(h) => h,
+        Err(_) => return arg.to_string(),
+    };
+
+    if arg == "~" {
+        return home_dir;
+    }
+
+    // Expand "~/..." to "$HOME/..."
+    let sep = if cfg!(windows) { '\\' } else { '/' };
+    if arg.starts_with(&format!("~{sep}")) {
+        let relative = &arg[2..];
+        let mut path = PathBuf::from(home_dir);
+        path.push(relative);
+        return path.to_string_lossy().into_owned();
+    }
+
+    // "~something" is not a home directory reference, keep as-is
+    arg.to_string()
+}
+
 fn main() {
     let logger = pretty_env_logger::formatted_builder()
         .parse_default_env()
@@ -190,29 +289,8 @@ fn main() {
 
     let current_dir = std::env::current_dir().unwrap_or_default();
     let matches = cli().get_matches_from({
-        std::env::args().map(|arg| {
-            let mut checked_arg = arg
-                .replace('\\', "/")
-                .replace("//", "/")
-                .trim_matches(['\n', '\r', '"', '\'', ' ', '\t'])
-                .to_string();
-
-            if checked_arg.starts_with("./") {
-                checked_arg = current_dir
-                    .join(&checked_arg[2..])
-                    .to_string_lossy()
-                    .into_owned();
-            }
-
-            #[cfg(not(windows))]
-            {
-                checked_arg
-            }
-            #[cfg(windows)]
-            {
-                checked_arg.replace("/", "\\")
-            }
-        })
+        std::env::args()
+            .map(|arg| normalize_arg(arg, &current_dir))
     });
 
     let results: Arc<Mutex<Vec<Result>>> = Arc::new(Mutex::new(vec![]));
@@ -279,14 +357,8 @@ fn main() {
                     let input_modified = get_file_modified_time(&input);
 
                     let mut img = handle_error!(input, decode(&input));
-                    let exif_metadata: Option<ExifMetadata> = {
-                        // Temporarily suppress little_exif error logs for images without EXIF
-                        let prev_level = log::max_level();
-                        log::set_max_level(log::LevelFilter::Off);
-                        let result = ExifMetadata::new_from_path(&input);
-                        log::set_max_level(prev_level);
-
-                        match result {
+                    let exif_metadata: Option<ExifMetadata> =
+                        match ExifMetadata::new_from_path(&input) {
                             Ok(exif) => {
                                 if strip_metadata {
                                     None
@@ -294,9 +366,11 @@ fn main() {
                                     Some(exif)
                                 }
                             }
-                            Err(_) => None,
-                        }
-                    };
+                            Err(e) => {
+                                log::debug!("{}: EXIF read skipped: {e}", input.display());
+                                None
+                            }
+                        };
 
                     pb.set_style(sty_aux_operations.clone());
 
@@ -356,20 +430,20 @@ fn main() {
                     pb.set_style(sty_aux_encode.clone());
 
                     if backup {
-                        handle_error!(
-                            input,
-                            fs::rename(
-                                &input,
-                                format!(
-                                    "{}@backup.{}",
-                                    input.file_stem().unwrap().to_str().unwrap(),
-                                    input.extension().unwrap().to_str().unwrap()
-                                ),
-                            )
+                        let backup_name = format!(
+                            "{}@backup.{}",
+                            input
+                                .file_stem()
+                                .and_then(|s| s.to_str())
+                                .unwrap_or("backup"),
+                            input.extension().and_then(|s| s.to_str()).unwrap_or("bak"),
                         );
+                        handle_error!(input, fs::rename(&input, backup_name));
                     }
 
-                    handle_error!(output, fs::create_dir_all(output.parent().unwrap()));
+                    if let Some(parent) = output.parent() {
+                        handle_error!(output, fs::create_dir_all(parent));
+                    }
                     let output_file = handle_error!(output, File::create(&output));
 
                     handle_error!(output, available_encoder.encode(&img, output_file));
@@ -391,8 +465,10 @@ fn main() {
                     let mut results = results.lock().unwrap();
                     let mut metadata = metadata.lock().unwrap();
 
-                    let absolute_input_path = fs::canonicalize(&input).unwrap();
-                    let absolute_output_path = fs::canonicalize(&output).unwrap();
+                    let absolute_input_path =
+                        fs::canonicalize(&input).unwrap_or_else(|_| input.clone());
+                    let absolute_output_path =
+                        fs::canonicalize(&output).unwrap_or_else(|_| output.clone());
 
                     results.push(Result {
                         output,
@@ -516,6 +592,6 @@ fn main() {
                 fs::write(metadata_path, json).unwrap();
             }
         }
-        std::prelude::v1::None => unreachable!(),
+        None => unreachable!("clap ensures a subcommand is always provided"),
     }
 }


### PR DESCRIPTION
- Fixed copy-paste errors in upscale/no-upscale help text that incorrectly described "reduce the size" instead of "increase".
- Improved mozjpeg smoothing comment: accurately notes that smoothing may slightly reduce sharpness, rather than claiming it doesn't affect quality. Simplified the smoothing clamp logic to use u8::max(10).
- Fixed dev-dependency version mismatch: zune-image dev-dep changed from 0.5.0-rc0 to 0.5.0 with explicit "jpeg" feature, matching the primary dependency version. Added zune-cor  dev-dep with "std" feature instead of version-locked 0.5.0.
- ~ expansion: ~/Desktop resolves to USERPROFILE\Desktop (Windows) or
  HOME/Desktop (Unix). Falls back to original value if env var unset.
- UNC detection: uses Path::components() and Prefix enum instead of
  fragile string matching (starts_with("\\\\")). Properly identifies
  VerbatimUNC, UNC, Verbatim, Disk, and DeviceNS prefixes.
- Relative path resolution: all relative paths (not just ./) are
  resolved against current_dir. Uses Path::is_absolute() and
  component-level prefix detection.
- Canonicalization: existing paths are canonicalized (resolves ..,
  symlinks, case). Non-existent paths (e.g. output dirs) keep the
  joined absolute path.
- Windows: preserves canonicalized UNC/verbatim prefixes as-is;
  normalizes regular paths to backslash separators.
- Unix: backslashes are preserved as valid filename characters
  (no longer incorrectly treated as path separators).


⑦