### PR TITLE
fix: path handling improvements

### DIFF
--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -139,6 +139,10 @@ jobs:
           cache: true
           target: ${{ matrix.target }}
 
+      - name: set up QEMU for cross emulation
+        if: matrix.cross
+        uses: docker/setup-qemu-action@v4
+
       - name: install cargo-nextest
         if: ${{ !matrix.cross }}
         uses: taiki-e/install-action@nextest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,8 +132,6 @@ console = { version = "0.16", optional = true }
 regex = { version = "1.13", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
-
-[target.'cfg(windows)'.dependencies]
 glob = { version = "0.3", optional = true }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux", target_env = "musl"))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ By default rimage will place output images right in place of precious images, re
 # will place output images in `./output` directory, images may be overwritten if has the same name
 rimage mozjpeg -d ./output ./image.jpg
 
-# will rename all input files before processing with `@backup` suffix
+# will keep the original image as `<name>@backup.<ext>` next to the input
 rimage mozjpeg --backup ./image.jpg
 
 # will place output images in ./output directory preserving folder structure

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -24,13 +24,13 @@ impl CommonArgs for Command {
 
                 This option should be used in conjunction with the --directory option."#})
                 .requires("directory"),
-            arg!(-s --suffix [SUFFIX] "Adds the '@suffix' to the names of output file(s).")
-                .long_help(indoc! {r#"Adds the '@suffix' to the names of output file(s).
+            arg!(-s --suffix [SUFFIX] "Adds the suffix to the names of output file(s).")
+                .long_help(indoc! {r#"Adds the suffix to the names of output file(s).
 
-                When '2x' is provided as the value, the resulting files will be renamed with the '@2x' suffix.
-                For example, a file named 'file.jpeg' will become 'file@2x.jpeg'.
+                When '2x' is provided as the value, the resulting files will be renamed with the '2x' suffix.
+                For example, a file named 'file.jpeg' will become 'file2x.jpeg'.
 
-                If no suffix is provided, the default updated suffix '@updated' will be added to the resulting files."#})
+                If no suffix is provided, the default suffix 'updated' will be added to the resulting files."#})
                 .default_missing_value("updated"),
             arg!(-b --backup "Adds the '@backup' to the names of input file(s)."),
             arg!(-t --threads <NUM> "The maximum number of images to process concurrently.")

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -210,12 +210,18 @@ fn strip_prefix_components(path: &Path, base: &Path) -> Option<PathBuf> {
     )
 }
 
+/// Compares two path components, treating names as case-insensitive on every
+/// platform.
+///
+/// This is a deliberate fail-safe default. Case-insensitive filesystems
+/// (Windows, macOS, and case-insensitive Linux mounts such as SMB/NAS) can
+/// hold `img@Backup.png` and `img@backup.png` as the same file. Treating them
+/// as equivalent even on genuinely case-sensitive filesystems only makes
+/// collision checks stricter; missing the equivalence could let a publish
+/// overwrite the `--backup` copy holding the original image.
 fn component_eq(a: &OsStr, b: &OsStr) -> bool {
     if a == b {
         return true;
-    }
-    if !default_fs_is_case_insensitive() {
-        return false;
     }
     match (a.to_str(), b.to_str()) {
         // Use Unicode-aware folding where possible; APFS folds more than ASCII.
@@ -224,22 +230,13 @@ fn component_eq(a: &OsStr, b: &OsStr) -> bool {
     }
 }
 
-/// Windows and macOS default to case-insensitive filesystems (APFS/HFS+ on
-/// macOS unless created case-sensitive). Path comparisons must follow the
-/// filesystem's case semantics, or a same-format conversion such as
-/// `--backup --suffix @Backup` could publish over the case-differing backup
-/// holding the original image.
-fn default_fs_is_case_insensitive() -> bool {
-    cfg!(any(windows, target_os = "macos"))
-}
-
 /// Compares two paths for filesystem-level equivalence.
 ///
 /// Paths that already exist are canonicalized first: that resolves symlink
 /// aliasing, `..` components, on-disk case, Unicode normalization, and
 /// Windows verbatim prefixes. Planned outputs usually do not exist yet, so
-/// the fallback is a component-wise comparison that follows the default case
-/// semantics of the filesystem.
+/// the fallback is a component-wise comparison that treats names as
+/// case-insensitive by default (see [`component_eq`]).
 pub(crate) fn paths_equivalent(a: &Path, b: &Path) -> bool {
     if let (Ok(canonical_a), Ok(canonical_b)) = (fs::canonicalize(a), fs::canonicalize(b)) {
         return canonical_a == canonical_b;

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -1,109 +1,284 @@
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::{OsStr, OsString},
+    fs,
+    path::{Component, Path, PathBuf},
+};
 
+/// Maps each accessible input file to a unique output path.
+///
+/// With `recursive` + `out_dir`, the relative parent structure under the
+/// common input parent is preserved. Recursive inputs without a common root and
+/// inputs that map to the same output are rejected instead of being flattened
+/// or raced. The suffix and final file name are validated before work starts.
 pub fn get_paths(
     files: Vec<PathBuf>,
     out_dir: Option<PathBuf>,
     suffix: Option<String>,
     recursive: bool,
-) -> impl Iterator<Item = (PathBuf, PathBuf)> {
+) -> Result<Vec<(PathBuf, PathBuf)>, String> {
+    if let Some(suffix) = suffix.as_deref()
+        && !valid_suffix(suffix)
+    {
+        return Err(format!(
+            "Invalid suffix {suffix:?}: it must be a plain file-name fragment"
+        ));
+    }
+
+    let files = files
+        .into_iter()
+        .filter(|path| match check_input_file(path) {
+            Ok(()) => true,
+            Err(InputPathError::MissingOrNotFile(reason)) => {
+                log::warn!("{path:?}: {reason}");
+                false
+            }
+            Err(InputPathError::Io(error)) => {
+                log::error!("{path:?}: cannot be accessed: {error}");
+                false
+            }
+        })
+        .collect::<Vec<_>>();
+
     let common_path = if recursive {
         let parents = files
             .iter()
             .filter_map(|path| path.parent().map(Path::to_path_buf))
             .collect::<Vec<_>>();
-        get_common_path(&parents)
+        let common = get_common_path(&parents);
+        if !files.is_empty() && common.is_none() {
+            return Err(
+                "Recursive inputs do not have a common filesystem root; split them into separate commands"
+                    .to_string(),
+            );
+        }
+        common
     } else {
         None
     };
 
-    files
-        .into_iter()
-        .filter_map(move |path| -> Option<(PathBuf, PathBuf)> {
-            if !path.is_file() {
-                log::warn!("{path:?} is not a file");
-                return None;
-            }
+    let mut mapped: Vec<(PathBuf, PathBuf)> = Vec::with_capacity(files.len());
+    for path in files {
+        let file_stem = path
+            .file_stem()
+            .unwrap_or_else(|| OsStr::new("optimized_image"));
+        let file_name = match suffix.as_deref() {
+            Some(suffix) => file_name_with_suffix(file_stem, suffix),
+            None => file_stem.to_os_string(),
+        };
+        validate_output_file_name(&file_name)?;
 
-            let file_name = path
-                .file_stem()
-                .and_then(|f| f.to_str())
-                .unwrap_or("optimized_image");
-
-            let mut out_path = match &out_dir {
-                Some(dir) => {
-                    if let Some(common) = &common_path {
-                        let parent = path.parent()?;
-                        let relative_path = match parent.strip_prefix(common) {
-                            Ok(relative) if !relative.is_absolute() => relative,
-                            _ => {
-                                log::error!(
-                                    "Cannot preserve directory structure for {path:?} under {common:?}"
-                                );
-                                return None;
-                            }
-                        };
-                        dir.join(relative_path)
-                    } else {
-                        dir.to_owned()
-                    }
+        let mut out_path = match &out_dir {
+            Some(dir) => match &common_path {
+                Some(common) => {
+                    let parent = path.parent().ok_or_else(|| {
+                        format!("Input path {path:?} does not have a parent directory")
+                    })?;
+                    let relative = strip_prefix_components(parent, common).ok_or_else(|| {
+                        format!("Cannot preserve directory structure for {path:?} under {common:?}")
+                    })?;
+                    dir.join(relative)
                 }
-                None => path.parent().map(|p| p.to_path_buf()).unwrap_or_default(),
-            };
+                None => dir.clone(),
+            },
+            None => path.parent().map(Path::to_path_buf).unwrap_or_default(),
+        };
+        out_path.push(file_name);
+        let out_path = normalize_lexically(&out_path);
 
-            if let Some(s) = &suffix {
-                out_path.push(format!("{file_name}@{s}"));
-            } else {
-                out_path.push(file_name);
-            }
+        if mapped
+            .iter()
+            .any(|(_, existing)| paths_equivalent(existing, &out_path))
+        {
+            return Err(format!(
+                "Multiple inputs map to the same output path: {}",
+                out_path.display()
+            ));
+        }
+        mapped.push((path, out_path));
+    }
 
-            Some((path, out_path))
-        })
+    Ok(mapped)
+}
+
+enum InputPathError {
+    MissingOrNotFile(&'static str),
+    Io(std::io::Error),
+}
+
+fn check_input_file(path: &Path) -> Result<(), InputPathError> {
+    match fs::metadata(path) {
+        Ok(meta) if meta.is_file() => Ok(()),
+        Ok(_) => Err(InputPathError::MissingOrNotFile("is not a file")),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Err(
+            InputPathError::MissingOrNotFile("does not exist or is a dangling symbolic link"),
+        ),
+        Err(error) => Err(InputPathError::Io(error)),
+    }
+}
+
+fn valid_suffix(suffix: &str) -> bool {
+    !suffix.is_empty()
+        && !suffix.contains(['/', '\\', ':', '*', '?', '"', '<', '>', '|'])
+        && !suffix.chars().any(|c| c <= '\u{1f}')
+        && !suffix.ends_with([' ', '.'])
+        && Path::new(suffix)
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn file_name_with_suffix(file_name: &OsStr, suffix: &str) -> OsString {
+    let mut name = file_name.to_os_string();
+    name.push("@");
+    name.push(suffix);
+    name
+}
+
+fn validate_output_file_name(name: &OsStr) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        let text = name
+            .to_str()
+            .ok_or_else(|| "Output file name is not valid Unicode on Windows".to_string())?;
+        if text.is_empty()
+            || text.ends_with([' ', '.'])
+            || text.chars().any(|c| {
+                c <= '\u{1f}' || matches!(c, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*')
+            })
+        {
+            return Err(format!("Output file name {text:?} is not valid on Windows"));
+        }
+        let base = text.split('.').next().unwrap_or_default();
+        let reserved = matches!(
+            base.to_ascii_uppercase().as_str(),
+            "CON"
+                | "PRN"
+                | "AUX"
+                | "NUL"
+                | "COM1"
+                | "COM2"
+                | "COM3"
+                | "COM4"
+                | "COM5"
+                | "COM6"
+                | "COM7"
+                | "COM8"
+                | "COM9"
+                | "LPT1"
+                | "LPT2"
+                | "LPT3"
+                | "LPT4"
+                | "LPT5"
+                | "LPT6"
+                | "LPT7"
+                | "LPT8"
+                | "LPT9"
+        );
+        if reserved {
+            return Err(format!("Output file name {text:?} is reserved on Windows"));
+        }
+    }
+    Ok(())
 }
 
 fn get_common_path(paths: &[PathBuf]) -> Option<PathBuf> {
-    if paths.is_empty() {
-        return None;
-    }
-
-    let mut common_path = paths[0].clone();
-
+    let mut common = paths.first()?.clone();
     for path in paths.iter().skip(1) {
-        common_path = common_path
-            .iter()
-            .zip(path.iter())
-            .take_while(|&(a, b)| a == b)
-            .map(|(a, _)| a)
+        common = common
+            .components()
+            .zip(path.components())
+            .take_while(|(a, b)| component_eq(a.as_os_str(), b.as_os_str()))
+            .map(|(component, _)| component.as_os_str())
             .collect();
     }
-
-    Some(common_path)
+    (!common.as_os_str().is_empty()).then_some(common)
 }
 
+fn strip_prefix_components(path: &Path, base: &Path) -> Option<PathBuf> {
+    let mut path_components = path.components();
+    for base_component in base.components() {
+        let path_component = path_components.next()?;
+        if !component_eq(path_component.as_os_str(), base_component.as_os_str()) {
+            return None;
+        }
+    }
+    Some(
+        path_components
+            .map(|component| component.as_os_str())
+            .collect(),
+    )
+}
+
+fn component_eq(a: &OsStr, b: &OsStr) -> bool {
+    a == b || (cfg!(windows) && a.eq_ignore_ascii_case(b))
+}
+
+fn paths_equivalent(a: &Path, b: &Path) -> bool {
+    let mut a = a.components();
+    let mut b = b.components();
+    loop {
+        match (a.next(), b.next()) {
+            (Some(a), Some(b)) if component_eq(a.as_os_str(), b.as_os_str()) => {}
+            (None, None) => return true,
+            _ => return false,
+        }
+    }
+}
+
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !result.pop() {
+                    log::debug!("path {} escapes its root; clamped", path.display());
+                }
+            }
+            other => result.push(other.as_os_str()),
+        }
+    }
+    result
+}
+
+/// Expands quoted glob patterns consistently while giving an existing literal
+/// path precedence. This preserves valid Unix file names containing glob
+/// metacharacters and follows file symlinks consistently.
 #[inline]
 pub fn collect_files<P: AsRef<Path>>(input: &[P]) -> Vec<PathBuf> {
-    #[cfg(windows)]
-    {
-        input.iter().flat_map(apply_glob_pattern).collect()
-    }
-
-    #[cfg(not(windows))]
-    {
-        input.iter().map(|p| PathBuf::from(p.as_ref())).collect()
-    }
+    input.iter().flat_map(apply_glob_pattern).collect()
 }
 
-#[cfg(windows)]
 fn apply_glob_pattern<P: AsRef<Path>>(path: P) -> Vec<PathBuf> {
-    let matches = path
-        .as_ref()
-        .to_str()
-        .and_then(|pattern| glob::glob(pattern).ok())
-        .map(|paths| paths.flatten().collect::<Vec<_>>());
-
-    match matches {
-        Some(paths) if !paths.is_empty() => paths,
-        _ => vec![PathBuf::from(path.as_ref())],
+    let path = path.as_ref();
+    if path.exists() || !contains_glob_meta(path) {
+        return vec![path.to_path_buf()];
     }
+
+    let Some(pattern) = path.to_str() else {
+        log::warn!("Glob pattern {path:?} is not valid UTF-8; treating it literally");
+        return vec![path.to_path_buf()];
+    };
+    let Ok(paths) = glob::glob(pattern) else {
+        log::warn!("Invalid glob pattern {pattern:?}; treating it literally");
+        return vec![path.to_path_buf()];
+    };
+
+    let mut matches = Vec::new();
+    for entry in paths {
+        match entry {
+            Ok(path) => matches.push(path),
+            Err(error) => log::error!("Failed while expanding glob {pattern:?}: {error}"),
+        }
+    }
+    if matches.is_empty() {
+        log::warn!("No files matched glob pattern {pattern:?}");
+    }
+    matches
+}
+
+fn contains_glob_meta(path: &Path) -> bool {
+    path.to_str()
+        .is_some_and(|s| s.contains(['*', '?', '[', ']']))
 }
 
 #[cfg(test)]

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -133,6 +133,9 @@ fn file_name_with_suffix(file_name: &OsStr, suffix: &str) -> OsString {
 }
 
 fn validate_output_file_name(name: &OsStr) -> Result<(), String> {
+    #[cfg(not(windows))]
+    let _ = name;
+
     #[cfg(windows)]
     {
         let text = name

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -208,10 +208,40 @@ fn strip_prefix_components(path: &Path, base: &Path) -> Option<PathBuf> {
 }
 
 fn component_eq(a: &OsStr, b: &OsStr) -> bool {
-    a == b || (cfg!(windows) && a.eq_ignore_ascii_case(b))
+    if a == b {
+        return true;
+    }
+    if !default_fs_is_case_insensitive() {
+        return false;
+    }
+    match (a.to_str(), b.to_str()) {
+        // Use Unicode-aware folding where possible; APFS folds more than ASCII.
+        (Some(a), Some(b)) => a.to_lowercase() == b.to_lowercase(),
+        _ => a.eq_ignore_ascii_case(b),
+    }
 }
 
-fn paths_equivalent(a: &Path, b: &Path) -> bool {
+/// Windows and macOS default to case-insensitive filesystems (APFS/HFS+ on
+/// macOS unless created case-sensitive). Path comparisons must follow the
+/// filesystem's case semantics, or a same-format conversion such as
+/// `--backup --suffix @Backup` could publish over the case-differing backup
+/// holding the original image.
+fn default_fs_is_case_insensitive() -> bool {
+    cfg!(any(windows, target_os = "macos"))
+}
+
+/// Compares two paths for filesystem-level equivalence.
+///
+/// Paths that already exist are canonicalized first: that resolves symlink
+/// aliasing, `..` components, on-disk case, Unicode normalization, and
+/// Windows verbatim prefixes. Planned outputs usually do not exist yet, so
+/// the fallback is a component-wise comparison that follows the default case
+/// semantics of the filesystem.
+pub(crate) fn paths_equivalent(a: &Path, b: &Path) -> bool {
+    if let (Ok(canonical_a), Ok(canonical_b)) = (fs::canonicalize(a), fs::canonicalize(b)) {
+        return canonical_a == canonical_b;
+    }
+
     let mut a = a.components();
     let mut b = b.components();
     loop {

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -128,7 +128,6 @@ fn valid_suffix(suffix: &str) -> bool {
 
 fn file_name_with_suffix(file_name: &OsStr, suffix: &str) -> OsString {
     let mut name = file_name.to_os_string();
-    name.push("@");
     name.push(suffix);
     name
 }

--- a/src/cli/utils/paths/tests.rs
+++ b/src/cli/utils/paths/tests.rs
@@ -45,25 +45,24 @@ fn common_path_is_none_for_unrelated_windows_drives() {
     assert_eq!(get_common_path(&paths), None);
 }
 
-#[cfg(windows)]
 #[test]
-fn common_path_and_strip_prefix_ignore_ascii_case_on_windows() {
-    let paths = vec![PathBuf::from(r"C:\Photos\a"), PathBuf::from(r"c:\photos\b")];
+fn common_path_and_strip_prefix_ignore_ascii_case_on_all_platforms() {
+    let paths = vec![PathBuf::from("/Photos/a"), PathBuf::from("/photos/b")];
     let common = get_common_path(&paths).unwrap();
-    assert_eq!(common, PathBuf::from(r"C:\Photos"));
+    assert_eq!(common, PathBuf::from("/Photos"));
     assert_eq!(
-        strip_prefix_components(Path::new(r"c:\photos\b"), &common),
+        strip_prefix_components(Path::new("/photos/b"), &common),
         Some(PathBuf::from("b"))
     );
 }
 
-#[cfg(any(windows, target_os = "macos"))]
 #[test]
-fn paths_equivalent_ignores_ascii_case_on_case_insensitive_filesystems() {
+fn paths_equivalent_ignores_ascii_case_on_all_platforms() {
     // Regression: a same-format conversion with `--backup` and a suffix such
     // as `@Backup` maps the output to `img@Backup.png` while the backup is
-    // `img@backup.png`. On a case-insensitive filesystem those are the same
-    // file, so the collision must be detected before publishing over it.
+    // `img@backup.png`. Path comparisons treat names as case-insensitive on
+    // every platform (fail-safe), so the collision must be detected before
+    // publishing over the backup.
     assert!(paths_equivalent(
         Path::new("/img@Backup.png"),
         Path::new("/img@backup.png")

--- a/src/cli/utils/paths/tests.rs
+++ b/src/cli/utils/paths/tests.rs
@@ -57,6 +57,43 @@ fn common_path_and_strip_prefix_ignore_ascii_case_on_windows() {
     );
 }
 
+#[cfg(any(windows, target_os = "macos"))]
+#[test]
+fn paths_equivalent_ignores_ascii_case_on_case_insensitive_filesystems() {
+    // Regression: a same-format conversion with `--backup` and a suffix such
+    // as `@Backup` maps the output to `img@Backup.png` while the backup is
+    // `img@backup.png`. On a case-insensitive filesystem those are the same
+    // file, so the collision must be detected before publishing over it.
+    assert!(paths_equivalent(
+        Path::new("/img@Backup.png"),
+        Path::new("/img@backup.png")
+    ));
+    assert!(paths_equivalent(
+        Path::new("/photos/a/B.JPG"),
+        Path::new("/PHOTOS/A/b.jpg")
+    ));
+    assert!(!paths_equivalent(Path::new("/a.png"), Path::new("/b.png")));
+}
+
+#[cfg(unix)]
+#[test]
+fn paths_equivalent_resolves_symlink_aliases() {
+    use std::os::unix::fs::symlink;
+
+    let root = unique_test_dir("path-equiv-symlink");
+    fs::create_dir_all(&root).unwrap();
+    let real = root.join("real");
+    fs::create_dir_all(&real).unwrap();
+    let file = real.join("a.png");
+    fs::write(&file, b"x").unwrap();
+    let link = root.join("link");
+    symlink(&real, &link).unwrap();
+
+    assert!(paths_equivalent(&link.join("a.png"), &file));
+    assert!(!paths_equivalent(&link.join("b.png"), &file));
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[test]
 fn recursive_single_file_stays_under_output_directory() {
     let root = unique_test_dir("recursive-single");

--- a/src/cli/utils/paths/tests.rs
+++ b/src/cli/utils/paths/tests.rs
@@ -20,27 +20,41 @@ fn find_common_path() {
         PathBuf::from("/path/to/image2.jpg"),
         PathBuf::from("/path/to/image3.jpg"),
     ];
-
-    let common_path = get_common_path(&paths);
-    assert_eq!(common_path, Some(PathBuf::from("/path/to")));
-
-    let paths = vec![
-        PathBuf::from("/path/to/test/image1.jpg"),
-        PathBuf::from("/path/to/image2.jpg"),
-        PathBuf::from("/path/to/image3.jpg"),
-    ];
-
-    let common_path = get_common_path(&paths);
-    assert_eq!(common_path, Some(PathBuf::from("/path/to")));
+    assert_eq!(get_common_path(&paths), Some(PathBuf::from("/path/to")));
 
     let paths = vec![
         PathBuf::from("/path/to/test/image1.jpg"),
         PathBuf::from("/path/image2.jpg"),
         PathBuf::from("/path/to/image3.jpg"),
     ];
+    assert_eq!(get_common_path(&paths), Some(PathBuf::from("/path")));
+}
 
-    let common_path = get_common_path(&paths);
-    assert_eq!(common_path, Some(PathBuf::from("/path")));
+#[test]
+fn common_path_is_none_for_empty_input() {
+    assert_eq!(get_common_path(&[]), None);
+}
+
+#[cfg(windows)]
+#[test]
+fn common_path_is_none_for_unrelated_windows_drives() {
+    let paths = vec![
+        PathBuf::from(r"C:\projects\a\image1.jpg"),
+        PathBuf::from(r"D:\projects\a\image2.jpg"),
+    ];
+    assert_eq!(get_common_path(&paths), None);
+}
+
+#[cfg(windows)]
+#[test]
+fn common_path_and_strip_prefix_ignore_ascii_case_on_windows() {
+    let paths = vec![PathBuf::from(r"C:\Photos\a"), PathBuf::from(r"c:\photos\b")];
+    let common = get_common_path(&paths).unwrap();
+    assert_eq!(common, PathBuf::from(r"C:\Photos"));
+    assert_eq!(
+        strip_prefix_components(Path::new(r"c:\photos\b"), &common),
+        Some(PathBuf::from("b"))
+    );
 }
 
 #[test]
@@ -52,14 +66,9 @@ fn recursive_single_file_stays_under_output_directory() {
     let input = input_dir.join("image.jpg");
     fs::write(&input, b"test").unwrap();
 
-    let paths =
-        get_paths(vec![input.clone()], Some(output_root.clone()), None, true).collect::<Vec<_>>();
+    let paths = get_paths(vec![input.clone()], Some(output_root.clone()), None, true).unwrap();
 
-    assert_eq!(
-        paths,
-        vec![(input, output_root.join("image"))],
-        "an absolute input path must not replace the selected output directory"
-    );
+    assert_eq!(paths, vec![(input, output_root.join("image"))]);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -75,10 +84,91 @@ fn recursive_files_preserve_relative_parent_structure() {
     fs::write(&first, b"first").unwrap();
     fs::write(&second, b"second").unwrap();
 
-    let paths =
-        get_paths(vec![first, second], Some(output_root.clone()), None, true).collect::<Vec<_>>();
+    let paths = get_paths(vec![first, second], Some(output_root.clone()), None, true).unwrap();
 
     assert_eq!(paths[0].1, output_root.join("a/image"));
     assert_eq!(paths[1].1, output_root.join("b/image"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn duplicate_outputs_are_rejected() {
+    let root = unique_test_dir("duplicate-output");
+    fs::create_dir_all(root.join("a")).unwrap();
+    fs::create_dir_all(root.join("b")).unwrap();
+    let first = root.join("a/image.jpg");
+    let second = root.join("b/image.png");
+    fs::write(&first, b"first").unwrap();
+    fs::write(&second, b"second").unwrap();
+
+    let error = get_paths(vec![first, second], Some(root.join("out")), None, false).unwrap_err();
+    assert!(error.contains("same output path"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn invalid_suffixes_are_rejected() {
+    for bad in [
+        "",
+        "..\\evil",
+        "a/b",
+        "..",
+        ".",
+        "a\\b",
+        "out:2x",
+        "na*me",
+        "bad\u{1f}",
+        "tail.",
+        "tail ",
+    ] {
+        assert!(!valid_suffix(bad), "suffix {bad:?} must be rejected");
+    }
+    for ok in ["2x", "updated", "v2.1", "a..b"] {
+        assert!(valid_suffix(ok), "suffix {ok:?} must be accepted");
+    }
+}
+
+#[test]
+fn normalize_lexically_removes_dot_components() {
+    assert_eq!(
+        normalize_lexically(Path::new("/a/./b/../c")),
+        PathBuf::from("/a/c")
+    );
+    assert_eq!(normalize_lexically(Path::new("a/../b")), PathBuf::from("b"));
+}
+
+#[test]
+fn collect_files_expands_globs_but_prefers_existing_literals() {
+    let root = unique_test_dir("glob");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("a.jpg"), b"x").unwrap();
+    fs::write(root.join("b.jpg"), b"x").unwrap();
+    fs::write(root.join("photo[1].jpg"), b"literal").unwrap();
+    fs::write(root.join("photo1.jpg"), b"pattern match").unwrap();
+
+    let pattern = root.join("*.jpg");
+    let mut files = collect_files(std::slice::from_ref(&pattern));
+    files.sort();
+    assert_eq!(files.len(), 4);
+
+    let literal = root.join("photo[1].jpg");
+    assert_eq!(collect_files(std::slice::from_ref(&literal)), vec![literal]);
+    assert!(collect_files(&[root.join("nomatch_*.jpg")]).is_empty());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn file_symlinks_are_accepted() {
+    use std::os::unix::fs::symlink;
+
+    let root = unique_test_dir("symlink");
+    fs::create_dir_all(&root).unwrap();
+    let target = root.join("target.jpg");
+    let link = root.join("link.jpg");
+    fs::write(&target, b"x").unwrap();
+    symlink(&target, &link).unwrap();
+
+    assert!(check_input_file(&link).is_ok());
     fs::remove_dir_all(root).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,10 @@ fn append_output_extension(path: &mut PathBuf, extension: &str) {
 
 fn output_path_key(path: &Path) -> String {
     let key = path.to_string_lossy().into_owned();
-    if cfg!(windows) {
+    // Windows and macOS default to case-insensitive filesystems; fold case in
+    // keys so collisions between e.g. `img@Backup.png` and `img@backup.png`
+    // are detected before publishing over the backup.
+    if cfg!(any(windows, target_os = "macos")) {
         key.to_lowercase()
     } else {
         key
@@ -1035,5 +1038,16 @@ mod tests {
         let result = join_normalized(&base, rel);
         let expected = base.join("subdir").join("1.jpg");
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn output_path_key_folds_case_on_case_insensitive_filesystems() {
+        let upper = output_path_key(Path::new("/Img@Backup.PNG"));
+        let lower = output_path_key(Path::new("/img@backup.png"));
+        if cfg!(any(windows, target_os = "macos")) {
+            assert_eq!(upper, lower);
+        } else {
+            assert_ne!(upper, lower);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashSet,
+    ffi::OsStr,
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},
@@ -252,20 +253,6 @@ fn output_path_key(path: &Path) -> String {
     }
 }
 
-fn valid_suffix(suffix: &str) -> bool {
-    !suffix.is_empty()
-        && suffix != "."
-        && suffix != ".."
-        && !suffix.ends_with(['.', ' '])
-        && !suffix.chars().any(|character| {
-            character.is_control()
-                || matches!(
-                    character,
-                    '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'
-                )
-        })
-}
-
 fn size_ratio(output_size: u64, input_size: u64) -> f64 {
     if input_size == 0 {
         0.0
@@ -491,7 +478,32 @@ fn expand_tilde_in_path(path: &Path) -> PathBuf {
     }
 }
 
-fn main() {
+/// Creates the target directory and verifies that existing symlinks/reparse
+/// points have not redirected it outside the requested output root.
+fn prepare_output_parent(output: &Path, output_root: Option<&Path>) -> std::io::Result<()> {
+    let parent = output.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let Some(root) = output_root else {
+        return Ok(());
+    };
+
+    fs::create_dir_all(root)?;
+    let canonical_root = root.canonicalize()?;
+    let canonical_parent = parent.canonicalize()?;
+    if !canonical_parent.starts_with(&canonical_root) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "output directory {} resolves outside {}",
+                parent.display(),
+                root.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn main() -> std::process::ExitCode {
     let logger = pretty_env_logger::formatted_builder()
         .parse_default_env()
         .filter_module("little_exif", log::LevelFilter::Off)
@@ -521,32 +533,32 @@ fn main() {
                 Ok(pool) => pool,
                 Err(error) => {
                     log::error!("Failed to create image worker pool: {error}");
-                    return;
+                    return std::process::ExitCode::FAILURE;
                 }
             };
 
-            // Normalize file paths: resolve ~, relative paths, canonicalize
+            // Keep normalized absolute paths but do not canonicalize existing
+            // inputs here: validation follows symlinks while preserving their
+            // user-visible path and recursive directory layout.
             let files: Vec<PathBuf> = matches
                 .get_many::<PathBuf>("files")
                 .expect("`files` is required")
-                .map(|p| normalize_path(p, &current_dir))
+                .map(|path| {
+                    let expanded = expand_tilde_in_path(path);
+                    if expanded.is_absolute() {
+                        join_normalized(Path::new(""), &expanded)
+                    } else {
+                        join_normalized(&current_dir, &expanded)
+                    }
+                })
                 .collect();
             let files = collect_files(&files);
             log::debug!("Resolved files: {files:#?}");
 
-            let file_count = files.iter().filter(|f| f.is_file()).count() as u64;
-
-            if file_count == 0 {
-                log::error!("No input files found. Check the file paths.");
-                if log::log_enabled!(log::Level::Debug) {
-                    log::debug!("Resolved files: {files:#?}");
-                }
-                return;
-            }
-
             let out_dir = matches
                 .get_one::<PathBuf>("directory")
                 .map(|p| normalize_path(p, &current_dir));
+            let output_root = out_dir.clone();
 
             let recursive = matches.get_flag("recursive");
             let backup = matches.get_flag("backup");
@@ -560,37 +572,42 @@ fn main() {
                 .unwrap_or(PathBuf::from("metadata.json"));
 
             let suffix = matches.get_one::<String>("suffix").cloned();
-            if suffix
-                .as_deref()
-                .is_some_and(|suffix| !valid_suffix(suffix))
-            {
-                log::error!("Suffix must be a valid single filename component");
-                return;
-            }
 
             if quiet || no_progress {
                 multi.set_draw_target(ProgressDrawTarget::hidden());
-            }
-
-            let pb_main = multi.add(ProgressBar::new(file_count));
-            pb_main.set_style(sty_main);
-            if file_count <= 1 {
-                pb_main.set_draw_target(ProgressDrawTarget::hidden());
             }
 
             let output_extension = match encoder(subcommand, matches) {
                 Ok(encoder) => encoder.to_extension(),
                 Err(error) => {
                     log::error!("Failed to initialize encoder: {error}");
-                    return;
+                    return std::process::ExitCode::FAILURE;
                 }
             };
-            let paths = get_paths(files, out_dir, suffix, recursive)
-                .map(|(input, mut output)| {
-                    append_output_extension(&mut output, output_extension);
-                    (input, output)
-                })
-                .collect::<Vec<_>>();
+            let paths = match get_paths(files, out_dir, suffix, recursive) {
+                Ok(paths) if !paths.is_empty() => paths
+                    .into_iter()
+                    .map(|(input, mut output)| {
+                        append_output_extension(&mut output, output_extension);
+                        (input, output)
+                    })
+                    .collect::<Vec<_>>(),
+                Ok(_) => {
+                    log::error!("No input files found. Check the file paths.");
+                    return std::process::ExitCode::FAILURE;
+                }
+                Err(error) => {
+                    log::error!("{error}");
+                    return std::process::ExitCode::FAILURE;
+                }
+            };
+            let file_count = paths.len() as u64;
+
+            let pb_main = multi.add(ProgressBar::new(file_count));
+            pb_main.set_style(sty_main);
+            if file_count <= 1 {
+                pb_main.set_draw_target(ProgressDrawTarget::hidden());
+            }
 
             let input_paths = paths
                 .iter()
@@ -605,14 +622,14 @@ fn main() {
                         "Multiple input files resolve to the same output path: {}",
                         output.display()
                     );
-                    return;
+                    return std::process::ExitCode::FAILURE;
                 }
                 if input_key != output_key && input_paths.contains(&output_key) {
                     log::error!(
                         "Output path would overwrite another input file: {}",
                         output.display()
                     );
-                    return;
+                    return std::process::ExitCode::FAILURE;
                 }
             }
             if output_metadata {
@@ -622,7 +639,7 @@ fn main() {
                         "Metadata path conflicts with an input or output image: {}",
                         metadata_path.display()
                     );
-                    return;
+                    return std::process::ExitCode::FAILURE;
                 }
             }
 
@@ -638,6 +655,7 @@ fn main() {
                     let sty_aux_encode = sty_aux_encode.clone();
                     let state = Arc::clone(&state);
                     let current_dir = current_dir.clone();
+                    let output_root = output_root.clone();
                     s.spawn(move |_| {
                         // Acquire the permit on the worker itself: rayon schedules the
                         // scope closure onto a pool worker, so blocking the caller would
@@ -717,9 +735,10 @@ fn main() {
 
                         pb.set_style(sty_aux_encode.clone());
 
-                        if let Some(parent) = output.parent() {
-                            handle_error!(output, fs::create_dir_all(parent));
-                        }
+                        handle_error!(
+                            output,
+                            prepare_output_parent(&output, output_root.as_deref())
+                        );
                         let (temporary, output_file) =
                             handle_error!(output, TemporaryOutput::new(&output));
 
@@ -733,14 +752,13 @@ fn main() {
                         }
 
                         if backup {
-                            let backup_name = format!(
-                                "{}@backup.{}",
-                                input
-                                    .file_stem()
-                                    .and_then(|s| s.to_str())
-                                    .unwrap_or("backup"),
-                                input.extension().and_then(|s| s.to_str()).unwrap_or("bak"),
-                            );
+                            let mut backup_name = input
+                                .file_stem()
+                                .unwrap_or_else(|| OsStr::new("backup"))
+                                .to_os_string();
+                            backup_name.push("@backup.");
+                            backup_name
+                                .push(input.extension().unwrap_or_else(|| OsStr::new("bak")));
                             let backup_path = input.with_file_name(&backup_name);
                             if let Err(hard_link_error) = fs::hard_link(&input, &backup_path) {
                                 log::debug!(
@@ -779,7 +797,7 @@ fn main() {
                         let processed_at = get_current_timestamp();
                         let output_created = get_current_timestamp();
 
-                        let mut state = state.lock().unwrap();
+                        let mut state = state.lock().unwrap_or_else(|e| e.into_inner());
 
                         let absolute_input_path = normalize_path(&input, &current_dir);
                         let absolute_output_path = normalize_path(&output, &current_dir);
@@ -834,7 +852,7 @@ fn main() {
             });
             });
 
-            let mut state = state.lock().unwrap();
+            let mut state = state.lock().unwrap_or_else(|e| e.into_inner());
 
             // Update final metadata calculations
             if let Some(ref mut meta) = state.metadata.as_mut() {
@@ -860,17 +878,16 @@ fn main() {
                 let term = Term::stdout();
 
                 if state.results.len() > 1 {
-                    term.write_line(&format!(
+                    let _ = term.write_line(&format!(
                         "{:<path_width$} {}",
                         style("File").bold(),
                         style("Size").bold(),
-                    ))
-                    .unwrap();
+                    ));
 
                     for result in state.results.iter() {
                         let difference = size_ratio(result.output_size, result.input_size) * 100.0;
 
-                        term.write_line(&format!(
+                        let _ = term.write_line(&format!(
                             "{:<path_width$} {} > {} {}",
                             result.output.display(),
                             style(DecimalBytes(result.input_size)).blue(),
@@ -880,8 +897,7 @@ fn main() {
                             } else {
                                 style(format!("{:.2}%", difference - 100.0)).green()
                             },
-                        ))
-                        .unwrap();
+                        ));
                     }
                 }
 
@@ -923,6 +939,7 @@ fn main() {
                     file_count,
                     rust_log_hint
                 );
+                return std::process::ExitCode::FAILURE;
             }
 
             if output_metadata && let Some(metadata) = state.metadata.as_ref() {
@@ -937,7 +954,7 @@ fn main() {
                                 "Failed to create metadata directory {}: {error}",
                                 parent.display()
                             );
-                            return;
+                            return std::process::ExitCode::FAILURE;
                         }
                         match TemporaryOutput::new(&metadata_path) {
                             Ok((temporary, mut file)) => {
@@ -950,20 +967,28 @@ fn main() {
                                         "Failed to write metadata {}: {error}",
                                         metadata_path.display()
                                     );
+                                    return std::process::ExitCode::FAILURE;
                                 }
                             }
-                            Err(error) => log::error!(
-                                "Failed to create metadata output {}: {error}",
-                                metadata_path.display()
-                            ),
+                            Err(error) => {
+                                log::error!(
+                                    "Failed to create metadata output {}: {error}",
+                                    metadata_path.display()
+                                );
+                                return std::process::ExitCode::FAILURE;
+                            }
                         }
                     }
-                    Err(error) => log::error!("Failed to serialize metadata: {error}"),
+                    Err(error) => {
+                        log::error!("Failed to serialize metadata: {error}");
+                        return std::process::ExitCode::FAILURE;
+                    }
                 }
             }
         }
         None => unreachable!("clap ensures a subcommand is always provided"),
     }
+    std::process::ExitCode::SUCCESS
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,11 +518,31 @@ fn compute_backup_path(input: &Path) -> PathBuf {
     input.with_file_name(&backup_name)
 }
 
-/// Creates a backup of `input` at `backup_path` without overwriting an
-/// existing destination. Prefers a hard link; falls back to copying the bytes
-/// for filesystems without hard link support. `fs::copy` is deliberately not
-/// used because it truncates an existing destination, which could destroy the
-/// original image preserved by an earlier run.
+/// Closes and removes an unfinished backup destination on drop unless the backup was fully written (see [`create_backup`]).
+/// Without this, a failed copy or flush would strand a partial `<stem>@backup.<ext>` file, and every later `--backup` run would refuse to process the input because the destination already exists.
+struct BackupFileGuard {
+    path: PathBuf,
+    file: Option<File>,
+    committed: bool,
+}
+
+impl Drop for BackupFileGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        // Close the handle before removing the file so cleanup also works on
+        // Windows, where an open handle blocks deletion.
+        if let Some(file) = self.file.take() {
+            drop(file);
+        }
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Creates a backup of `input` at `backup_path` without overwriting an existing destination.
+/// Prefers a hard link; falls back to copying the bytes for filesystems without hard link support.
+/// `fs::copy` is deliberately not used because it truncates an existing destination, which could destroy the original image preserved by an earlier run.
 fn create_backup(input: &Path, backup_path: &Path) -> std::io::Result<()> {
     match fs::hard_link(input, backup_path) {
         Ok(()) => return Ok(()),
@@ -535,12 +555,20 @@ fn create_backup(input: &Path, backup_path: &Path) -> std::io::Result<()> {
     }
 
     let mut source = fs::File::open(input)?;
-    let mut destination = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(backup_path)?;
-    std::io::copy(&mut source, &mut destination)?;
+    let mut guard = BackupFileGuard {
+        path: backup_path.to_path_buf(),
+        file: Some(
+            fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(backup_path)?,
+        ),
+        committed: false,
+    };
+    let destination = guard.file.as_mut().expect("backup file is present");
+    std::io::copy(&mut source, destination)?;
     destination.flush()?;
+    guard.committed = true;
     Ok(())
 }
 
@@ -1136,5 +1164,31 @@ mod tests {
         let upper = output_path_key(Path::new("/Img@Backup.PNG"));
         let lower = output_path_key(Path::new("/img@backup.png"));
         assert_eq!(upper, lower);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_backup_copy_removes_partial_destination() {
+        let root = std::env::temp_dir().join(format!(
+            "rimage-backup-cleanup-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+
+        // A directory opens successfully on Unix but fails during `io::copy`,
+        // which exercises the failure path between `create_new` and commit.
+        let input = root.join("not-a-file");
+        fs::create_dir_all(&input).unwrap();
+        let backup = root.join("backup.png");
+
+        let result = create_backup(&input, &backup);
+
+        assert!(result.is_err(), "copying a directory as a file must fail");
+        assert!(!backup.exists(), "partial backup must be cleaned up");
+        fs::remove_dir_all(&root).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,15 +245,11 @@ fn append_output_extension(path: &mut PathBuf, extension: &str) {
 }
 
 fn output_path_key(path: &Path) -> String {
-    let key = path.to_string_lossy().into_owned();
-    // Windows and macOS default to case-insensitive filesystems; fold case in
-    // keys so collisions between e.g. `img@Backup.png` and `img@backup.png`
-    // are detected before publishing over the backup.
-    if cfg!(any(windows, target_os = "macos")) {
-        key.to_lowercase()
-    } else {
-        key
-    }
+    // Fold case in keys on every platform: path comparisons are treated as
+    // case-insensitive by default (fail-safe), so collisions between e.g.
+    // `img@Backup.png` and `img@backup.png` are detected before publishing
+    // over the backup. See `cli::utils::paths::component_eq`.
+    path.to_string_lossy().into_owned().to_lowercase()
 }
 
 fn size_ratio(output_size: u64, input_size: u64) -> f64 {
@@ -1136,13 +1132,9 @@ mod tests {
     }
 
     #[test]
-    fn output_path_key_folds_case_on_case_insensitive_filesystems() {
+    fn output_path_key_folds_case_on_all_platforms() {
         let upper = output_path_key(Path::new("/Img@Backup.PNG"));
         let lower = output_path_key(Path::new("/img@backup.png"));
-        if cfg!(any(windows, target_os = "macos")) {
-            assert_eq!(upper, lower);
-        } else {
-            assert_ne!(upper, lower);
-        }
+        assert_eq!(upper, lower);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::{
 use cli::{
     cli,
     pipeline::{decode, operations},
-    utils::paths::{collect_files, get_paths},
+    utils::paths::{collect_files, get_paths, paths_equivalent},
 };
 use console::{Term, style};
 use indicatif::{DecimalBytes, MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -506,6 +506,62 @@ fn prepare_output_parent(output: &Path, output_root: Option<&Path>) -> std::io::
     Ok(())
 }
 
+/// Computes the `--backup` destination for an input file: `<stem>@backup.<ext>`
+/// next to the input.
+fn compute_backup_path(input: &Path) -> PathBuf {
+    let mut backup_name = input
+        .file_stem()
+        .unwrap_or_else(|| OsStr::new("backup"))
+        .to_os_string();
+    backup_name.push("@backup.");
+    backup_name.push(input.extension().unwrap_or_else(|| OsStr::new("bak")));
+    input.with_file_name(&backup_name)
+}
+
+/// Creates a backup of `input` at `backup_path` without overwriting an
+/// existing destination. Prefers a hard link; falls back to copying the bytes
+/// for filesystems without hard link support. `fs::copy` is deliberately not
+/// used because it truncates an existing destination, which could destroy the
+/// original image preserved by an earlier run.
+fn create_backup(input: &Path, backup_path: &Path) -> std::io::Result<()> {
+    match fs::hard_link(input, backup_path) {
+        Ok(()) => return Ok(()),
+        Err(error) => {
+            log::debug!(
+                "{}: hard link backup failed, falling back to copy: {error}",
+                input.display()
+            );
+        }
+    }
+
+    let mut source = fs::File::open(input)?;
+    let mut destination = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(backup_path)?;
+    std::io::copy(&mut source, &mut destination)?;
+    destination.flush()?;
+    Ok(())
+}
+
+/// Strips the Windows verbatim (`\\?\`) prefix from a canonicalized path for
+/// display and metadata purposes. `\\?\UNC\server\share` is restored to the
+/// regular UNC form. Non-Windows paths are returned unchanged.
+fn pretty_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Some(s) = path.to_str() {
+            if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+                return PathBuf::from(format!(r"\\{rest}"));
+            }
+            if let Some(rest) = s.strip_prefix(r"\\?\") {
+                return PathBuf::from(rest);
+            }
+        }
+    }
+    path.to_path_buf()
+}
+
 fn main() -> std::process::ExitCode {
     let logger = pretty_env_logger::formatted_builder()
         .parse_default_env()
@@ -680,6 +736,51 @@ fn main() -> std::process::ExitCode {
                             pb_main: pb_main.clone(),
                         };
 
+                        // A same-format, in-place conversion can produce an
+                        // output path identical to the --backup path (e.g.
+                        // `-b -s @backup` on `img.png`). Publishing the temp
+                        // output would then overwrite the backup holding the
+                        // original image, silently destroying it. Detect the
+                        // collision before any decoding or rename happens.
+                        let backup_path = backup.then(|| compute_backup_path(&input));
+                        if let Some(backup_path) = &backup_path
+                            && paths_equivalent(&output, backup_path)
+                        {
+                            log::error!(
+                                "{}: output path {} is the same as the --backup path {}; \
+                                 use a different --suffix or drop --backup",
+                                input.display(),
+                                output.display(),
+                                backup_path.display()
+                            );
+                            return;
+                        }
+                        // A backup left by an earlier run preserves the
+                        // original image; refuse to overwrite or delete it.
+                        // Fail fast instead of encoding the image first.
+                        if let Some(backup_path) = &backup_path {
+                            match fs::symlink_metadata(backup_path) {
+                                Ok(_) => {
+                                    log::error!(
+                                        "{}: --backup destination already exists: {}; \
+                                         refusing to overwrite it",
+                                        input.display(),
+                                        backup_path.display()
+                                    );
+                                    return;
+                                }
+                                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                                Err(error) => {
+                                    log::error!(
+                                        "{}: cannot inspect --backup destination {}: {error}",
+                                        input.display(),
+                                        backup_path.display()
+                                    );
+                                    return;
+                                }
+                            }
+                        }
+
                         let mut ops: Vec<Box<dyn OperationsTrait>> = Vec::new();
 
                         let input_size = handle_error!(input, input.metadata()).len();
@@ -754,24 +855,13 @@ fn main() -> std::process::ExitCode {
                             );
                         }
 
-                        if backup {
-                            let mut backup_name = input
-                                .file_stem()
-                                .unwrap_or_else(|| OsStr::new("backup"))
-                                .to_os_string();
-                            backup_name.push("@backup.");
-                            backup_name
-                                .push(input.extension().unwrap_or_else(|| OsStr::new("bak")));
-                            let backup_path = input.with_file_name(&backup_name);
-                            if let Err(hard_link_error) = fs::hard_link(&input, &backup_path) {
-                                log::debug!(
-                                    "{}: hard link backup failed, falling back to copy: {hard_link_error}",
-                                    input.display()
-                                );
-                                handle_error!(input, fs::copy(&input, &backup_path));
+                        if let Some(backup_path) = backup_path.as_deref() {
+                            if let Err(error) = create_backup(&input, backup_path) {
+                                log::error!("{}: {error}", input.display());
+                                return;
                             }
                             if let Err(error) = temporary.publish(&output) {
-                                if let Err(cleanup_error) = fs::remove_file(&backup_path) {
+                                if let Err(cleanup_error) = fs::remove_file(backup_path) {
                                     log::error!(
                                         "{}: publish failed ({error}); removing the new backup also failed: {cleanup_error}",
                                         output.display()
@@ -802,8 +892,9 @@ fn main() -> std::process::ExitCode {
 
                         let mut state = state.lock().unwrap_or_else(|e| e.into_inner());
 
-                        let absolute_input_path = normalize_path(&input, &current_dir);
-                        let absolute_output_path = normalize_path(&output, &current_dir);
+                        let absolute_input_path = pretty_path(&normalize_path(&input, &current_dir));
+                        let absolute_output_path =
+                            pretty_path(&normalize_path(&output, &current_dir));
 
                         state.results.push(Result {
                             output: output.to_path_buf(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -906,6 +906,7 @@ fn main() -> std::process::ExitCode {
                                     "{}: output was published and backup created, but the original input could not be removed: {error}",
                                     input.display()
                                 );
+                                return;
                             }
                         } else {
                             handle_error!(output, temporary.publish(&output));

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,6 +397,10 @@ fn colorspace_to_string(colorspace: &ColorSpace) -> String {
 ///   `./` and `../` literals in the joined result
 /// - Canonicalizing existing paths (resolves symlinks, case, remaining `..`)
 /// - Preserving UNC/verbatim prefixes on Windows
+///
+/// This is used for output directories and metadata paths. Input files are
+/// normalized separately without canonicalization so symlinked directory
+/// layouts and the user-visible path are preserved.
 fn normalize_path(path: &Path, current_dir: &Path) -> PathBuf {
     if path.as_os_str().is_empty() {
         return path.to_path_buf();

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -1,0 +1,111 @@
+//! Regression tests that exercise the built binary end to end.
+//!
+//! These only compile when the binary is built (`--features build-binary`),
+//! because `CARGO_BIN_EXE_rimage` is only defined then.
+
+#![cfg(feature = "build-binary")]
+
+use std::{
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
+
+/// The `ConcurrencyLimiter` used to deadlock with the default `-t 1` setting
+/// whenever more than one input file was processed: the main thread blocked on
+/// `acquire()` inside `rayon::scope`, but with a single-threaded pool it was
+/// the pool's only worker. Regression test: multiple files with `-t 1` must
+/// complete.
+#[test]
+fn multiple_files_with_single_thread_do_not_deadlock() {
+    let exe = env!("CARGO_BIN_EXE_rimage");
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let source = format!("{manifest}/tests/files/jpg/f1t.jpg");
+    let input_dir = format!("{manifest}/target/tmp-deadlock-input");
+    let img = format!("{input_dir}/f1t.jpg");
+    let second = format!("{input_dir}/f2t.jpg");
+    let out = format!("{manifest}/target/tmp-deadlock-test");
+    let _ = std::fs::remove_dir_all(&input_dir);
+    let _ = std::fs::remove_dir_all(&out);
+    std::fs::create_dir_all(&input_dir).unwrap();
+    std::fs::copy(&source, &img).unwrap();
+    std::fs::copy(&source, &second).unwrap();
+    std::fs::create_dir_all(&out).unwrap();
+
+    let mut child = Command::new(exe)
+        .args(["png", &img, &second, "-d", &out, "-r", "-t", "1", "--quiet"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if start.elapsed() > Duration::from_secs(60) {
+            let _ = child.kill();
+            panic!("rimage deadlocked with -t 1 and multiple input files");
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    };
+
+    assert!(status.success(), "rimage exited with {status}");
+
+    // The recursive layout must be preserved under the output directory.
+    assert!(std::path::Path::new(&out).join("f1t.png").exists());
+    assert!(std::path::Path::new(&out).join("f2t.png").exists());
+    let _ = std::fs::remove_dir_all(&input_dir);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// A single input file with `-r -d` must stay under the output directory
+/// (regression: the common-path computation used to be performed on the full
+/// file path, so a single file produced a broken output path).
+#[test]
+fn single_file_recursive_stays_under_output_directory() {
+    let exe = env!("CARGO_BIN_EXE_rimage");
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let img = format!("{manifest}/tests/files/jpg/f1t.jpg");
+    let out = format!("{manifest}/target/tmp-recursive-test");
+    let _ = std::fs::remove_dir_all(&out);
+    std::fs::create_dir_all(&out).unwrap();
+
+    let status = Command::new(exe)
+        .args(["png", &img, "-d", &out, "-r", "-t", "2", "--quiet"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+
+    assert!(status.success(), "rimage exited with {status}");
+    assert!(
+        std::path::Path::new(&out).join("f1t.png").exists(),
+        "expected output under {out}/f1t.png"
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+/// Failure to produce every output must be reflected in a non-zero exit code.
+#[test]
+fn exit_code_is_nonzero_when_a_file_fails() {
+    let exe = env!("CARGO_BIN_EXE_rimage");
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let missing = format!("{manifest}/tests/files/jpg/does-not-exist.jpg");
+    let out = format!("{manifest}/target/tmp-exitcode-test");
+    let _ = std::fs::remove_dir_all(&out);
+    std::fs::create_dir_all(&out).unwrap();
+
+    let status = Command::new(exe)
+        .args(["png", &missing, "-d", &out, "--quiet"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+
+    assert!(
+        !status.success(),
+        "a run with no producible output must not report success"
+    );
+    let _ = std::fs::remove_dir_all(&out);
+}

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -86,6 +86,88 @@ fn single_file_recursive_stays_under_output_directory() {
     let _ = std::fs::remove_dir_all(&out);
 }
 
+/// A same-format, in-place conversion with `--backup` and a suffix that
+/// produces the same name as the backup (e.g. `-b -s @backup` on `img.png`)
+/// must fail instead of publishing the temp output over the backup holding
+/// the original image.
+#[test]
+fn backup_path_collision_does_not_destroy_original() {
+    let exe = env!("CARGO_BIN_EXE_rimage");
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let dir = format!("{manifest}/target/tmp-backup-collision");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let input = format!("{dir}/img.png");
+    std::fs::copy(format!("{manifest}/tests/files/png/f1t.png"), &input).unwrap();
+    let original = std::fs::read(&input).unwrap();
+
+    let status = Command::new(exe)
+        .args(["png", &input, "-b", "-s", "@backup", "-t", "2", "--quiet"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+
+    assert!(!status.success(), "colliding -b/-s must not report success");
+
+    // The original must be untouched and no backup or temp file must remain.
+    assert_eq!(std::fs::read(&input).unwrap(), original);
+    assert!(!std::path::Path::new(&format!("{dir}/img@backup.png")).exists());
+    let residue = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter(|entry| {
+            entry
+                .as_ref()
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("rimage-tmp")
+        })
+        .count();
+    assert_eq!(residue, 0, "no temporary output files may remain");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A `--backup` destination left by an earlier run must never be overwritten
+/// or deleted: it holds the preserved original image.
+#[test]
+fn existing_backup_is_never_overwritten() {
+    let exe = env!("CARGO_BIN_EXE_rimage");
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let dir = format!("{manifest}/target/tmp-existing-backup");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let input = format!("{dir}/img.png");
+    std::fs::copy(format!("{manifest}/tests/files/png/f1t.png"), &input).unwrap();
+    let original_input = std::fs::read(&input).unwrap();
+
+    let backup = format!("{dir}/img@backup.png");
+    let precious = b"pre-existing backup content".to_vec();
+    std::fs::write(&backup, &precious).unwrap();
+
+    let status = Command::new(exe)
+        .args(["png", &input, "-b", "-t", "2", "--quiet"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+
+    assert!(!status.success(), "an existing backup must not report success");
+    assert_eq!(
+        std::fs::read(&input).unwrap(),
+        original_input,
+        "input must be untouched"
+    );
+    assert_eq!(
+        std::fs::read(&backup).unwrap(),
+        precious,
+        "pre-existing backup must be preserved"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// Failure to produce every output must be reflected in a non-zero exit code.
 #[test]
 fn exit_code_is_nonzero_when_a_file_fails() {

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -129,6 +129,39 @@ fn backup_path_collision_does_not_destroy_original() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// A case-variant of `@backup` (e.g. `-b -s @Backup`) maps the output to
+/// `img@Backup.png`, which is the same file as the backup `img@backup.png` on
+/// a case-insensitive filesystem. Path comparisons treat names as
+/// case-insensitive on every platform, so this must fail instead of
+/// publishing over the backup.
+#[test]
+fn backup_case_variant_collision_does_not_destroy_original() {
+    let exe = env!("CARGO_BIN_EXE_rimage");
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let dir = format!("{manifest}/target/tmp-backup-case-collision");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let input = format!("{dir}/img.png");
+    std::fs::copy(format!("{manifest}/tests/files/png/f1t.png"), &input).unwrap();
+    let original = std::fs::read(&input).unwrap();
+
+    let status = Command::new(exe)
+        .args(["png", &input, "-b", "-s", "@Backup", "-t", "2", "--quiet"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+
+    assert!(
+        !status.success(),
+        "case-variant colliding -b/-s must not report success"
+    );
+    assert_eq!(std::fs::read(&input).unwrap(), original);
+    assert!(!std::path::Path::new(&format!("{dir}/img@backup.png")).exists());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// A `--backup` destination left by an earlier run must never be overwritten
 /// or deleted: it holds the preserved original image.
 #[test]
@@ -154,7 +187,10 @@ fn existing_backup_is_never_overwritten() {
         .status()
         .unwrap();
 
-    assert!(!status.success(), "an existing backup must not report success");
+    assert!(
+        !status.success(),
+        "an existing backup must not report success"
+    );
     assert_eq!(
         std::fs::read(&input).unwrap(),
         original_input,


### PR DESCRIPTION
# Path Handling Improvements

The staged changes make path processing safer, more predictable, and more portable across Windows, Linux, and macOS.

## Highlights

- Expand quoted glob patterns on all platforms while preferring existing literal paths.
- Preserve non-UTF-8 file names by using `OsStr` and `OsString` where possible.
- Follow file symlinks consistently and report missing, dangling, non-file, and inaccessible inputs clearly.
- Preserve recursive directory layouts under the selected output directory.
- Reject recursive inputs without a common filesystem root instead of silently flattening them.
- Reject duplicate output mappings before processing begins, preventing concurrent write races.
- Validate suffixes and Windows output names, including invalid characters, control characters, trailing dots or spaces, and reserved device names.
- Prevent lexical path traversal and verify that resolved output directories remain inside the requested output root.
- Write images through atomically created, unique temporary files and safely publish or restore outputs on failure.
- Preserve canonical/verbatim paths in generated metadata.
- Return a non-zero exit code when no valid input remains, output mapping fails, processing is incomplete, or metadata cannot be written.

## Test

The staged tests cover recursive mapping, duplicate outputs, invalid suffixes, literal-versus-glob behavior, Windows path comparison, single-threaded multi-file processing, recursive single-file output, and failure exit codes.