### PR TITLE
Feat: Add support for multi-paths which might  overflow Windows args limits using `file.list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to the Rimage library will be documented in this file.
 
+# 0.13.0
+
+### Breaking Changes
+
+- append the output suffix directly WITHOUT an automatic `@` separator (`-s 2x` now yields `file2x.jpeg`) and update the CLI help accordingly
+
+### Features
+
+- expand glob patterns in input paths on all platforms (previously Windows-only), preferring existing literal paths
+
+### Bug Fixes
+
+- fix a deadlock with a single-threaded pool by acquiring the concurrency permit inside the worker, and return an error instead of panicking when the thread pool cannot be created
+- write outputs atomically through unique temporary files and publish them by rename, with a recoverable swap when replacing existing files on Windows
+- detect collisions before any processing: duplicate output mappings, outputs overwriting another input, metadata path conflicts, and output paths identical to `--backup` paths (path names are treated as case-insensitive on every platform as a fail-safe default, covering case-insensitive Linux mounts, and aliases are resolved through canonicalization for existing paths)
+- never overwrite or delete an existing `--backup` file; create backups via hard link with a no-clobber copy fallback and remove the original input only after a successful publish
+- normalize input paths without canonicalization so symlinked directory layouts are preserved, and reject output parents that resolve outside the output root
+- return non-zero exit codes when no inputs are found, an encoder fails, a collision is detected, files fail, or metadata cannot be written
+- fix WebP animation encoding by warning and encoding only the first frame; compute per-frame durations from timestamps in the decoder
+- guard against empty frame lists in the AVIF, MozJPEG, OxiPNG and WebP encoders instead of panicking
+- restrict MozJPEG to 8-bit output and fix OxiPNG 16-bit endianness for non-RGB colorspaces
+- apply ICC profiles to 16-bit frames without panicking and preserve frame timing metadata
+- prevent integer overflow panics in quantization and resize, and surface resize worker panics as errors
+
+### Improvements
+
+- validate suffixes and output file names (including Windows reserved names) up front, reject recursive inputs without a common root and duplicate output mappings with clear errors
+- write JSON metadata atomically and use saturating arithmetic for size and space-saved statistics
+- add end-to-end regression tests covering single-thread processing, recursive output layouts, backup collisions, existing-backup protection and non-zero exit codes
+- regenerate the AVIF test fixture
+
+### Dependencies
+
+- bump `zune-imageprocs` to 0.5.1 (stable) and `regex` to 1.13
+- bump `jxl-grid` to 0.6.2, `jxl-oxide` to 0.12.6, `log` to 0.4.33, `indicatif` to 0.18.6, `anyhow` to 1.0.103 and `serde_json` to 1.0.150
+- replace `winres` with `winresource` 0.1.31 and make `glob` a general dependency
+- pin `ravif` 0.13.0 without default features for `aarch64-unknown-linux-musl`
+
+### Build / CI
+
+- rewrite the CI workflow: build and test on `main` and `dev`, Ubuntu 24.04 / Windows 2025 / macOS 15 runners, cross builds for `aarch64-unknown-linux-musl` with a pinned image, qemu runner for aarch64 Linux, `actions/checkout@v7`, concurrency grouping and read-only permissions
+- use yasm for the libaom build, fix artifact download errors and silence Homebrew tap warnings on macOS
+- remove the `config.toml` pre-release override and set the Windows pre-release version in `build.rs`
+
 # [0.12.4](https://github.com/SalOne22/rimage/compare/v0.12.3...v0.12.4) (2026-05-23)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ All notable changes to the Rimage library will be documented in this file.
 ### Breaking Changes
 
 - append the output suffix directly WITHOUT an automatic `@` separator (`-s 2x` now yields `file2x.jpeg`) and update the CLI help accordingly
+- accept a UTF-8 `file.list` as an input file list, with one file path per line (blank lines are skipped, surrounding whitespace is ignored, and relative paths are resolved against the current working directory); when a `file.list` is provided, all other input file arguments are ignored
 
 ### Features
 
 - expand glob patterns in input paths on all platforms (previously Windows-only), preferring existing literal paths
-- accept a UTF-8 `file.list` as an input file list, with one file path per line (blank lines are skipped, surrounding whitespace is ignored, and relative paths are resolved against the current working directory); when a `file.list` is provided, all other input file arguments are ignored
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Rimage library will be documented in this file.
 ### Features
 
 - expand glob patterns in input paths on all platforms (previously Windows-only), preferring existing literal paths
+- accept a UTF-8 `file.list` as an input file list, with one file path per line (blank lines are skipped, surrounding whitespace is ignored, and relative paths are resolved against the current working directory); when a `file.list` is provided, all other input file arguments are ignored
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ rimage mozjpeg --backup ./image.jpg
 rimage mozjpeg -d ./output -r ./inner/image.jpg ./image.jpg
 ```
 
+### File lists
+
+To process many images without a long command line, create a UTF-8 text file named `file.list`
+with one input file per line and pass it as an input:
+
+```sh
+rimage mozjpeg file.list
+```
+
+Blank lines are skipped, surrounding whitespace is ignored, and relative paths are resolved
+against the current working directory. Glob patterns are supported on each line. When a
+`file.list` is provided, all other input file arguments are ignored.
+
 ### Preprocessing
 
 Rimage supports a preprocessing pipeline: resize, color quantization, and alpha premultiply

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -12,7 +12,9 @@ impl CommonArgs for Command {
             arg!(files: <FILES> ... "Input file(s) to process.")
                 .long_help(indoc! {r#"Input file(s) to process.
 
-                If the file path contains spaces, enclose the path with double quotation marks on both sides."#})
+                If the file path contains spaces, enclose the path with double quotation marks on both sides.
+
+                A file named `file.list` is read as a UTF-8 file list with one input file per line. Blank lines are skipped, surrounding whitespace is ignored, and relative paths are resolved against the current working directory. When a `file.list` is provided, all other input file arguments are ignored."#})
                 .value_parser(value_parser!(PathBuf)),
             arg!(-d --directory <DIR> "The directory to write output file(s) to.")
                 .long_help(indoc! {r#"The directory to write output file(s) to.

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -310,5 +310,72 @@ fn contains_glob_meta(path: &Path) -> bool {
         .is_some_and(|s| s.contains(['*', '?', '[', ']']))
 }
 
+/// File name of the UTF-8 file list that is expanded into its listed inputs.
+const FILE_LIST_NAME: &str = "file.list";
+
+/// Expands `file.list` inputs into the files they list.
+///
+/// When at least one input is a `file.list`, all other input arguments are
+/// ignored and only the file lists are expanded. Each `file.list` (compared
+/// case-insensitively as a fail-safe default) is read as a UTF-8 text file
+/// containing one file path per line. Blank lines and surrounding whitespace
+/// are ignored. Every listed path is passed through `normalize` (tilde
+/// expansion and current-directory joining) and then expanded with
+/// [`collect_files`], so glob patterns work inside the list. Nested
+/// `file.list` entries are not expanded recursively.
+pub fn expand_file_lists<F>(inputs: &[PathBuf], normalize: F) -> Result<Vec<PathBuf>, String>
+where
+    F: Fn(&Path) -> PathBuf,
+{
+    let has_file_list = inputs.iter().any(|input| is_file_list_path(input));
+    if has_file_list {
+        let ignored = inputs
+            .iter()
+            .filter(|input| !is_file_list_path(input))
+            .collect::<Vec<_>>();
+        if !ignored.is_empty() {
+            log::warn!(
+                "file.list input(s) provided; ignoring {} other input argument(s)",
+                ignored.len()
+            );
+            log::debug!("Ignored input arguments: {ignored:#?}");
+        }
+    }
+
+    let mut files = Vec::new();
+    for input in inputs {
+        if is_file_list_path(input) {
+            for entry in read_file_list_entries(input)? {
+                let normalized = normalize(&entry);
+                files.extend(collect_files(std::slice::from_ref(&normalized)));
+            }
+        } else if !has_file_list {
+            files.extend(collect_files(std::slice::from_ref(input)));
+        }
+    }
+    Ok(files)
+}
+
+fn is_file_list_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case(FILE_LIST_NAME))
+}
+
+fn read_file_list_entries(path: &Path) -> Result<Vec<PathBuf>, String> {
+    let content = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "Failed to read file list {} as UTF-8: {error}",
+            path.display()
+        )
+    })?;
+    Ok(content
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect())
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -370,8 +370,19 @@ fn read_file_list_entries(path: &Path) -> Result<Vec<PathBuf>, String> {
         )
     })?;
     Ok(content
+        .strip_prefix('\u{FEFF}')
+        .unwrap_or(&content)
         .lines()
-        .map(str::trim)
+        .map(|s| {
+            let s = s.trim().trim_matches(['"', '\'', '/', '\\']);
+            if s.contains("\u{FFFD}") {
+                log::warn!(
+                    "Line {s} in `file.list` {} may not encoding with valid UTF-8.",
+                    path.display()
+                );
+            }
+            s
+        })
         .filter(|line| !line.is_empty())
         .map(PathBuf::from)
         .collect())

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -374,7 +374,11 @@ fn read_file_list_entries(path: &Path) -> Result<Vec<PathBuf>, String> {
         .unwrap_or(&content)
         .lines()
         .map(|s| {
-            let s = s.trim().trim_matches(['"', '\'', '/', '\\']);
+            let s = s
+                .trim()
+                .trim_matches(['"', '\''])
+                .trim_end_matches(['\\', '/']);
+
             if s.contains("\u{FFFD}") {
                 log::warn!(
                     "Line {s} in `file.list` {} may not encoding with valid UTF-8.",

--- a/src/cli/utils/paths/tests.rs
+++ b/src/cli/utils/paths/tests.rs
@@ -193,6 +193,106 @@ fn collect_files_expands_globs_but_prefers_existing_literals() {
     fs::remove_dir_all(root).unwrap();
 }
 
+#[test]
+fn file_list_name_matches_case_insensitively() {
+    assert!(is_file_list_path(Path::new("file.list")));
+    assert!(is_file_list_path(Path::new("./FILE.LIST")));
+    assert!(is_file_list_path(&Path::new("dir").join("File.List")));
+    assert!(!is_file_list_path(Path::new("other.list")));
+    assert!(!is_file_list_path(Path::new("file.txt")));
+    assert!(!is_file_list_path(Path::new("myfile.list")));
+}
+
+#[test]
+fn file_list_reads_one_path_per_line() {
+    let root = unique_test_dir("file-list");
+    fs::create_dir_all(&root).unwrap();
+    let list = root.join("file.list");
+    fs::write(
+        &list,
+        b"photos/a.jpg\r\n  photos/b.jpg\t\n\n   \n#not-a-comment.jpg\n",
+    )
+    .unwrap();
+
+    let entries = read_file_list_entries(&list).unwrap();
+    assert_eq!(
+        entries,
+        vec![
+            PathBuf::from("photos/a.jpg"),
+            PathBuf::from("photos/b.jpg"),
+            PathBuf::from("#not-a-comment.jpg"),
+        ]
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn file_list_must_be_readable_utf8() {
+    let root = unique_test_dir("file-list-utf8");
+    fs::create_dir_all(&root).unwrap();
+    let list = root.join("file.list");
+    fs::write(&list, b"\xff\xfe invalid utf-8").unwrap();
+
+    let error = read_file_list_entries(&list).unwrap_err();
+    assert!(error.contains("file.list"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn expand_file_lists_uses_only_lists_and_ignores_other_inputs() {
+    let root = unique_test_dir("expand-file-list");
+    fs::create_dir_all(root.join("photos")).unwrap();
+    fs::write(root.join("photos/a.jpg"), b"a").unwrap();
+    fs::write(root.join("photos/a.png"), b"a").unwrap();
+    fs::write(root.join("photos/b.png"), b"b").unwrap();
+    fs::write(root.join("direct.jpg"), b"d").unwrap();
+    fs::write(root.join("file.list"), "photos/a.jpg\nphotos/*.png\n\n").unwrap();
+
+    let mut files = expand_file_lists(&[root.join("file.list"), root.join("direct.jpg")], |path| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            root.join(path)
+        }
+    })
+    .unwrap();
+    files.sort();
+
+    let mut expected = vec![
+        root.join("photos/a.jpg"),
+        root.join("photos/a.png"),
+        root.join("photos/b.png"),
+    ];
+    expected.sort();
+    assert_eq!(files, expected);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn expand_file_lists_without_lists_keeps_all_inputs() {
+    let root = unique_test_dir("expand-without-list");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("direct.jpg"), b"d").unwrap();
+    fs::write(root.join("other.png"), b"o").unwrap();
+
+    let direct = root.join("direct.jpg");
+    let other = root.join("other.png");
+    let mut files = expand_file_lists(&[direct.clone(), other.clone()], |path| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            root.join(path)
+        }
+    })
+    .unwrap();
+    files.sort();
+
+    let mut expected = vec![direct, other];
+    expected.sort();
+    assert_eq!(files, expected);
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[cfg(unix)]
 #[test]
 fn file_symlinks_are_accepted() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::{
 use cli::{
     cli,
     pipeline::{decode, operations},
-    utils::paths::{collect_files, get_paths, paths_equivalent},
+    utils::paths::{expand_file_lists, get_paths, paths_equivalent},
 };
 use console::{Term, style};
 use indicatif::{DecimalBytes, MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -627,19 +627,26 @@ fn main() -> std::process::ExitCode {
             // Keep normalized absolute paths but do not canonicalize existing
             // inputs here: validation follows symlinks while preserving their
             // user-visible path and recursive directory layout.
-            let files: Vec<PathBuf> = matches
+            let normalize_input = |path: &Path| {
+                let expanded = expand_tilde_in_path(path);
+                if expanded.is_absolute() {
+                    join_normalized(Path::new(""), &expanded)
+                } else {
+                    join_normalized(&current_dir, &expanded)
+                }
+            };
+            let inputs: Vec<PathBuf> = matches
                 .get_many::<PathBuf>("files")
                 .expect("`files` is required")
-                .map(|path| {
-                    let expanded = expand_tilde_in_path(path);
-                    if expanded.is_absolute() {
-                        join_normalized(Path::new(""), &expanded)
-                    } else {
-                        join_normalized(&current_dir, &expanded)
-                    }
-                })
+                .map(|path| normalize_input(path))
                 .collect();
-            let files = collect_files(&files);
+            let files = match expand_file_lists(&inputs, normalize_input) {
+                Ok(files) => files,
+                Err(error) => {
+                    log::error!("{error}");
+                    return std::process::ExitCode::FAILURE;
+                }
+            };
             log::debug!("Resolved files: {files:#?}");
 
             let out_dir = matches

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -227,3 +227,49 @@ fn exit_code_is_nonzero_when_a_file_fails() {
     );
     let _ = std::fs::remove_dir_all(&out);
 }
+
+/// A `file.list` input is expanded into the files it lists, one per line, and
+/// any other input arguments are ignored.
+#[test]
+fn file_list_expands_to_its_listed_inputs() {
+    let exe = env!("CARGO_BIN_EXE_rimage");
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let source = format!("{manifest}/tests/files/jpg/f1t.jpg");
+    let input_dir = format!("{manifest}/target/tmp-file-list-input");
+    let first = format!("{input_dir}/first.jpg");
+    let second = format!("{input_dir}/second.jpg");
+    let ignored = format!("{input_dir}/ignored.jpg");
+    let list = format!("{input_dir}/file.list");
+    let out = format!("{manifest}/target/tmp-file-list-test");
+    let _ = std::fs::remove_dir_all(&input_dir);
+    let _ = std::fs::remove_dir_all(&out);
+    std::fs::create_dir_all(&input_dir).unwrap();
+    std::fs::copy(&source, &first).unwrap();
+    std::fs::copy(&source, &second).unwrap();
+    std::fs::copy(&source, &ignored).unwrap();
+    std::fs::write(&list, format!("{first}\n{second}\n")).unwrap();
+    std::fs::create_dir_all(&out).unwrap();
+
+    let status = Command::new(exe)
+        .args(["png", &list, &ignored, "-d", &out, "--quiet"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap();
+
+    assert!(status.success(), "rimage exited with {status}");
+    assert!(
+        std::path::Path::new(&out).join("first.png").exists(),
+        "expected output under {out}/first.png"
+    );
+    assert!(
+        std::path::Path::new(&out).join("second.png").exists(),
+        "expected output under {out}/second.png"
+    );
+    assert!(
+        !std::path::Path::new(&out).join("ignored.png").exists(),
+        "other input arguments must be ignored when file.list is provided"
+    );
+    let _ = std::fs::remove_dir_all(&input_dir);
+    let _ = std::fs::remove_dir_all(&out);
+}


### PR DESCRIPTION
Accept a UTF-8 `file.list` as an input file list, with one file path per line (blank lines are skipped, surrounding whitespace is ignored, and relative paths are resolved against the current working directory) to avoid lots of paths overflow Windows Parms limits.

Besides, when a `file.list` is provided, all other input file arguments are ignored.

CLOSE #374 