### PR TITLE
feat: add longest and shortest side resize values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Rimage library will be documented in this file.
 
+# Unreleased
+
+### Features
+
+- add `100l` and `100s` resize values that anchor on the longest or shortest side of each image ([#377](https://github.com/SalOne22/rimage/pull/377))
+- add `--reduce-only` and `--enlarge-only` as aliases for `--no-upscale` and `--no-downscale` ([#377](https://github.com/SalOne22/rimage/pull/377))
+
 # [0.12.4](https://github.com/SalOne22/rimage/compare/v0.12.3...v0.12.4) (2026-05-23)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ rimage mozjpeg --resize 100w ./image.jpg
 rimage mozjpeg --resize 1000l ./images
 
 # Shrink images above 1000px only, leaving anything already smaller untouched
-# --reduce is an alias for --no-upscale, --enlarge for --no-downscale
-rimage mozjpeg --resize 1000l --reduce ./images
+# --reduce-only is an alias for --no-upscale, --enlarge-only for --no-downscale
+rimage mozjpeg --resize 1000l --reduce-only ./images
 ```
 
 #### Quantization (color palette reduction)

--- a/README.md
+++ b/README.md
@@ -109,7 +109,13 @@ rimage mozjpeg --resize 1000l ./images
 # Shrink images above 1000px only, leaving anything already smaller untouched
 # --reduce-only is an alias for --no-upscale, --enlarge-only for --no-downscale
 rimage mozjpeg --resize 1000l --reduce-only ./images
+
+# Grow images below 1000px only, leaving anything already larger untouched
+rimage mozjpeg --resize 1000l --enlarge-only ./images
 ```
+
+> **Note**: Passing both `--reduce-only` and `--enlarge-only` leaves no direction to resize
+> in, so every image keeps its original size. The order of the two flags makes no difference.
 
 #### Quantization (color palette reduction)
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ rimage mozjpeg --resize 500x200 ./image.jpg
 
 # Resize by width, preserving aspect ratio (200h for height)
 rimage mozjpeg --resize 100w ./image.jpg
+
+# Resize by the longest side, preserving aspect ratio (1000s for the shortest side)
+# The anchor is chosen per image, so portrait and landscape images in the same
+# batch both end up with a 1000px longest side
+rimage mozjpeg --resize 1000l ./images
+
+# Shrink images above 1000px only, leaving anything already smaller untouched
+rimage mozjpeg --resize 1000l --no-upscale ./images
 ```
 
 #### Quantization (color palette reduction)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ rimage mozjpeg --resize 100w ./image.jpg
 rimage mozjpeg --resize 1000l ./images
 
 # Shrink images above 1000px only, leaving anything already smaller untouched
-rimage mozjpeg --resize 1000l --no-upscale ./images
+# --reduce is an alias for --no-upscale, --enlarge for --no-downscale
+rimage mozjpeg --resize 1000l --reduce ./images
 ```
 
 #### Quantization (color palette reduction)

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -456,3 +456,183 @@ pub fn encoder(name: &str, matches: &ArgMatches) -> Result<AvailableEncoders, Im
         ))),
     }
 }
+
+#[cfg(all(test, feature = "resize"))]
+mod tests {
+    use zune_core::colorspace::ColorSpace;
+
+    use super::*;
+    use crate::cli::cli;
+
+    /// Builds the codec subcommand matches the way `main` passes them to [`operations`].
+    ///
+    /// `farbfeld` is used because it is the one codec that is never feature gated.
+    fn matches_from(args: &[&str]) -> ArgMatches {
+        cli()
+            .get_matches_from(args)
+            .subcommand()
+            .expect("clap ensures a subcommand is always provided")
+            .1
+            .clone()
+    }
+
+    fn test_image(width: usize, height: usize) -> Image {
+        Image::from_fn(width, height, ColorSpace::RGB, |x, y, px: &mut [u8; 4]| {
+            px[0] = x as u8;
+            px[1] = 0;
+            px[2] = y as u8;
+        })
+    }
+
+    /// Runs the preprocessing pipeline over an image of the given size.
+    ///
+    /// Reports how many resize operations were queued next to the resulting
+    /// dimensions, because "the image already fits" means none were queued at all.
+    fn run(resize_args: &[&str], width: usize, height: usize) -> (usize, (usize, usize)) {
+        let mut args = vec!["rimage", "farbfeld"];
+        args.extend_from_slice(resize_args);
+        args.push("image.ff");
+
+        let matches = matches_from(&args);
+        let mut img = test_image(width, height);
+
+        let ops = operations(&matches, &img);
+        let queued = ops.values().filter(|op| op.name() == "fast resize").count();
+
+        for op in ops.values() {
+            op.execute(&mut img).unwrap();
+        }
+
+        (queued, img.dimensions())
+    }
+
+    #[test]
+    fn longest_side_anchors_per_orientation() {
+        assert_eq!(run(&["--resize", "1000l"], 2000, 1000), (1, (1000, 500)));
+        assert_eq!(run(&["--resize", "1000l"], 1000, 2000), (1, (500, 1000)));
+        assert_eq!(run(&["--resize", "1000l"], 1600, 1600), (1, (1000, 1000)));
+    }
+
+    #[test]
+    fn shortest_side_anchors_per_orientation() {
+        assert_eq!(run(&["--resize", "500s"], 2000, 1000), (1, (1000, 500)));
+        assert_eq!(run(&["--resize", "500s"], 1000, 2000), (1, (500, 1000)));
+        assert_eq!(run(&["--resize", "500s"], 1600, 1600), (1, (500, 500)));
+    }
+
+    #[test]
+    fn side_value_is_skipped_when_the_image_already_fits_exactly() {
+        assert_eq!(run(&["--resize", "1000l"], 1000, 500), (0, (1000, 500)));
+        assert_eq!(run(&["--resize", "500s"], 1000, 500), (0, (1000, 500)));
+    }
+
+    #[test]
+    fn no_upscale_leaves_smaller_images_untouched() {
+        // The whole point of the flag pair: images already under the target
+        // keep their original size instead of being blown up to it.
+        assert_eq!(
+            run(&["--resize", "1000l", "--no-upscale"], 800, 400),
+            (0, (800, 400))
+        );
+
+        assert_eq!(
+            run(&["--resize", "500s", "--no-upscale"], 800, 400),
+            (0, (800, 400))
+        );
+    }
+
+    #[test]
+    fn no_upscale_still_shrinks_larger_images() {
+        assert_eq!(
+            run(&["--resize", "1000l", "--no-upscale"], 4000, 2000),
+            (1, (1000, 500))
+        );
+
+        assert_eq!(
+            run(&["--resize", "1000l", "--no-upscale"], 2000, 4000),
+            (1, (500, 1000))
+        );
+    }
+
+    #[test]
+    fn no_downscale_leaves_larger_images_untouched() {
+        assert_eq!(
+            run(&["--resize", "1000l", "--no-downscale"], 4000, 2000),
+            (0, (4000, 2000))
+        );
+
+        assert_eq!(
+            run(&["--resize", "500s", "--no-downscale"], 4000, 2000),
+            (0, (4000, 2000))
+        );
+    }
+
+    #[test]
+    fn no_downscale_still_enlarges_smaller_images() {
+        assert_eq!(
+            run(&["--resize", "1000l", "--no-downscale"], 800, 400),
+            (1, (1000, 500))
+        );
+
+        assert_eq!(
+            run(&["--resize", "1000l", "--no-downscale"], 400, 800),
+            (1, (500, 1000))
+        );
+    }
+
+    #[test]
+    fn a_mixed_batch_ends_up_with_a_consistent_longest_side() {
+        // This is the case `100w` cannot express: with a fixed width anchor the
+        // portrait images below would come out far taller than the landscape
+        // ones are wide.
+        for (width, height) in [(4000, 3000), (3000, 4000), (2000, 2000), (1200, 900)] {
+            let (_, (new_width, new_height)) = run(&["--resize", "1000l"], width, height);
+
+            assert_eq!(
+                new_width.max(new_height),
+                1000,
+                "{width}x{height} gave {new_width}x{new_height}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mixed_batch_ends_up_with_a_consistent_shortest_side() {
+        for (width, height) in [(4000, 3000), (3000, 4000), (2000, 2000), (1200, 900)] {
+            let (_, (new_width, new_height)) = run(&["--resize", "500s"], width, height);
+
+            assert_eq!(
+                new_width.min(new_height),
+                500,
+                "{width}x{height} gave {new_width}x{new_height}"
+            );
+        }
+    }
+
+    #[test]
+    fn shrink_only_batch_touches_only_oversized_images() {
+        // 1000l with --no-upscale is the shrink only mode from the feature
+        // request: everything ends up at or below 1000px, and anything that was
+        // already small keeps its exact original size.
+        let batch = [
+            ((4000, 3000), (1000, 750)),
+            ((3000, 4000), (750, 1000)),
+            ((800, 600), (800, 600)),
+            ((1000, 1000), (1000, 1000)),
+        ];
+
+        for ((width, height), expected) in batch {
+            let (_, dimensions) = run(&["--resize", "1000l", "--no-upscale"], width, height);
+
+            assert_eq!(dimensions, expected, "failed on {width}x{height}");
+        }
+    }
+
+    #[test]
+    fn side_values_compose_with_the_filter_flag() {
+        assert_eq!(
+            run(&["--resize", "1000l", "--filter", "nearest"], 2000, 1000),
+            (1, (1000, 500))
+        );
+    }
+}

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -694,6 +694,44 @@ mod tests {
     }
 
     #[test]
+    fn disabling_both_directions_skips_every_resize() {
+        // Neither flag wins over the other, they both apply, which leaves no
+        // direction to resize in. The order they are passed does not matter.
+        for args in [
+            ["--resize", "1000l", "--no-upscale", "--no-downscale"],
+            ["--resize", "1000l", "--no-downscale", "--no-upscale"],
+            ["--resize", "1000l", "--reduce-only", "--enlarge-only"],
+        ] {
+            assert_eq!(run(&args, 4000, 2000), (0, (4000, 2000)));
+            assert_eq!(run(&args, 800, 400), (0, (800, 400)));
+            assert_eq!(run(&args, 1000, 500), (0, (1000, 500)));
+        }
+    }
+
+    #[test]
+    fn chained_resize_values_all_map_the_original_size() {
+        // Every value maps the source dimensions rather than the size the
+        // previous resize left behind, so the last value decides the result and
+        // the earlier ones are overwritten.
+        assert_eq!(
+            run(&["--resize", "100x400", "--resize", "200s"], 800, 400),
+            (2, (400, 200))
+        );
+
+        assert_eq!(
+            run(&["--resize", "1000l", "--resize", "50%"], 800, 400),
+            (2, (400, 200))
+        );
+
+        // Two side values land on the same target here only because both of
+        // them map the same source dimensions.
+        assert_eq!(
+            run(&["--resize", "1000l", "--resize", "500s"], 800, 400),
+            (2, (1000, 500))
+        );
+    }
+
+    #[test]
     fn side_values_compose_with_the_filter_flag() {
         assert_eq!(
             run(&["--resize", "1000l", "--filter", "nearest"], 2000, 1000),

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -629,46 +629,46 @@ mod tests {
     }
 
     #[test]
-    fn reduce_is_an_alias_for_no_upscale() {
+    fn reduce_only_is_an_alias_for_no_upscale() {
         for (width, height) in [(4000, 2000), (800, 400), (1000, 500)] {
             assert_eq!(
-                run(&["--resize", "1000l", "--reduce"], width, height),
+                run(&["--resize", "1000l", "--reduce-only"], width, height),
                 run(&["--resize", "1000l", "--no-upscale"], width, height),
-                "--reduce diverged from --no-upscale on {width}x{height}"
+                "--reduce-only diverged from --no-upscale on {width}x{height}"
             );
         }
     }
 
     #[test]
-    fn enlarge_is_an_alias_for_no_downscale() {
+    fn enlarge_only_is_an_alias_for_no_downscale() {
         for (width, height) in [(4000, 2000), (800, 400), (1000, 500)] {
             assert_eq!(
-                run(&["--resize", "1000l", "--enlarge"], width, height),
+                run(&["--resize", "1000l", "--enlarge-only"], width, height),
                 run(&["--resize", "1000l", "--no-downscale"], width, height),
-                "--enlarge diverged from --no-downscale on {width}x{height}"
+                "--enlarge-only diverged from --no-downscale on {width}x{height}"
             );
         }
     }
 
     #[test]
-    fn reduce_and_enlarge_pick_the_direction_their_names_promise() {
+    fn reduce_only_and_enlarge_only_pick_the_direction_their_names_promise() {
         // Guards against the aliases being wired to the opposite flag, which is
         // the whole risk of naming a double negative.
         assert_eq!(
-            run(&["--resize", "1000l", "--reduce"], 4000, 2000),
+            run(&["--resize", "1000l", "--reduce-only"], 4000, 2000),
             (1, (1000, 500))
         );
         assert_eq!(
-            run(&["--resize", "1000l", "--reduce"], 800, 400),
+            run(&["--resize", "1000l", "--reduce-only"], 800, 400),
             (0, (800, 400))
         );
 
         assert_eq!(
-            run(&["--resize", "1000l", "--enlarge"], 800, 400),
+            run(&["--resize", "1000l", "--enlarge-only"], 800, 400),
             (1, (1000, 500))
         );
         assert_eq!(
-            run(&["--resize", "1000l", "--enlarge"], 4000, 2000),
+            run(&["--resize", "1000l", "--enlarge-only"], 4000, 2000),
             (0, (4000, 2000))
         );
     }
@@ -680,15 +680,15 @@ mod tests {
         // height follows the aspect ratio, and images at or under the cap keep
         // their original size.
         assert_eq!(
-            run(&["--resize", "400w", "--reduce"], 200, 100),
+            run(&["--resize", "400w", "--reduce-only"], 200, 100),
             (0, (200, 100))
         );
         assert_eq!(
-            run(&["--resize", "400w", "--reduce"], 400, 2000),
+            run(&["--resize", "400w", "--reduce-only"], 400, 2000),
             (0, (400, 2000))
         );
         assert_eq!(
-            run(&["--resize", "400w", "--reduce"], 800, 900),
+            run(&["--resize", "400w", "--reduce-only"], 800, 900),
             (1, (400, 450))
         );
     }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -674,6 +674,26 @@ mod tests {
     }
 
     #[test]
+    fn width_anchor_with_reduce_caps_the_width_only() {
+        // Capping one dimension however long the other one is does not need a
+        // side value at all, the existing width anchor already covers it. The
+        // height follows the aspect ratio, and images at or under the cap keep
+        // their original size.
+        assert_eq!(
+            run(&["--resize", "400w", "--reduce"], 200, 100),
+            (0, (200, 100))
+        );
+        assert_eq!(
+            run(&["--resize", "400w", "--reduce"], 400, 2000),
+            (0, (400, 2000))
+        );
+        assert_eq!(
+            run(&["--resize", "400w", "--reduce"], 800, 900),
+            (1, (400, 450))
+        );
+    }
+
+    #[test]
     fn side_values_compose_with_the_filter_flag() {
         assert_eq!(
             run(&["--resize", "1000l", "--filter", "nearest"], 2000, 1000),

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -629,6 +629,51 @@ mod tests {
     }
 
     #[test]
+    fn reduce_is_an_alias_for_no_upscale() {
+        for (width, height) in [(4000, 2000), (800, 400), (1000, 500)] {
+            assert_eq!(
+                run(&["--resize", "1000l", "--reduce"], width, height),
+                run(&["--resize", "1000l", "--no-upscale"], width, height),
+                "--reduce diverged from --no-upscale on {width}x{height}"
+            );
+        }
+    }
+
+    #[test]
+    fn enlarge_is_an_alias_for_no_downscale() {
+        for (width, height) in [(4000, 2000), (800, 400), (1000, 500)] {
+            assert_eq!(
+                run(&["--resize", "1000l", "--enlarge"], width, height),
+                run(&["--resize", "1000l", "--no-downscale"], width, height),
+                "--enlarge diverged from --no-downscale on {width}x{height}"
+            );
+        }
+    }
+
+    #[test]
+    fn reduce_and_enlarge_pick_the_direction_their_names_promise() {
+        // Guards against the aliases being wired to the opposite flag, which is
+        // the whole risk of naming a double negative.
+        assert_eq!(
+            run(&["--resize", "1000l", "--reduce"], 4000, 2000),
+            (1, (1000, 500))
+        );
+        assert_eq!(
+            run(&["--resize", "1000l", "--reduce"], 800, 400),
+            (0, (800, 400))
+        );
+
+        assert_eq!(
+            run(&["--resize", "1000l", "--enlarge"], 800, 400),
+            (1, (1000, 500))
+        );
+        assert_eq!(
+            run(&["--resize", "1000l", "--enlarge"], 4000, 2000),
+            (0, (4000, 2000))
+        );
+    }
+
+    #[test]
     fn side_values_compose_with_the_filter_flag() {
         assert_eq!(
             run(&["--resize", "1000l", "--filter", "nearest"], 2000, 1000),

--- a/src/cli/preprocessors/mod.rs
+++ b/src/cli/preprocessors/mod.rs
@@ -59,6 +59,7 @@ impl Preprocessors for Command {
 
                     This is useful when you don't want to reduce the size of the image when it is larger than the specified size.
                     Images that are already larger than the specified size are left untouched, so this is the enlarge only mode.
+                    Passing it together with --no-upscale leaves no direction to resize in, so every image keeps its original size.
                     It is recommended to use this option with --resize"#})
                     .visible_alias("enlarge-only")
                     .action(ArgAction::SetTrue)
@@ -80,6 +81,7 @@ impl Preprocessors for Command {
 
                     This is useful when you don't want to increase the size of the image when it is smaller than the specified size.
                     Images that are already smaller than the specified size are left untouched, so this is the reduce only mode.
+                    Passing it together with --no-downscale leaves no direction to resize in, so every image keeps its original size.
                     It is recommended to use this option with --resize"#})
                     .visible_alias("reduce-only")
                     .action(ArgAction::SetTrue)

--- a/src/cli/preprocessors/mod.rs
+++ b/src/cli/preprocessors/mod.rs
@@ -39,7 +39,7 @@ impl Preprocessors for Command {
 
                     The longest and shortest side values pick the anchor per image, so a batch of
                     mixed portrait and landscape images comes out at a consistent size. Combine them
-                    with --no-upscale or --no-downscale to leave images that already fit untouched."#})
+                    with --reduce or --enlarge to leave images that already fit untouched."#})
                     .value_parser(value_parser!(ResizeValue))
                     .action(ArgAction::Append),
 
@@ -55,10 +55,12 @@ impl Preprocessors for Command {
                     .overrides_with("no-downscale"),
                 #[cfg(feature = "resize")]
                 arg!(--"no-downscale" "Disable downscaling when resizing.")
-                    .long_help(indoc! {r#"Disable downscaling when resizing.
+                    .long_help(indoc! {r#"Disable downscaling when resizing. [aliases: --enlarge]
 
                     This is useful when you don't want to reduce the size of the image when it is larger than the specified size.
+                    Images that are already larger than the specified size are left untouched, so this is the enlarge only mode.
                     It is recommended to use this option with --resize"#})
+                    .visible_alias("enlarge")
                     .action(ArgAction::SetTrue)
                     .requires("resize"),
 
@@ -74,10 +76,12 @@ impl Preprocessors for Command {
                     .overrides_with("no-upscale"),
                 #[cfg(feature = "resize")]
                 arg!(--"no-upscale" "Disable upscaling when resizing.")
-                    .long_help(indoc! {r#"Disable upscaling when resizing.
+                    .long_help(indoc! {r#"Disable upscaling when resizing. [aliases: --reduce]
 
                     This is useful when you don't want to increase the size of the image when it is smaller than the specified size.
+                    Images that are already smaller than the specified size are left untouched, so this is the reduce only mode.
                     It is recommended to use this option with --resize"#})
+                    .visible_alias("reduce")
                     .action(ArgAction::SetTrue)
                     .requires("resize"),
 

--- a/src/cli/preprocessors/mod.rs
+++ b/src/cli/preprocessors/mod.rs
@@ -39,7 +39,7 @@ impl Preprocessors for Command {
 
                     The longest and shortest side values pick the anchor per image, so a batch of
                     mixed portrait and landscape images comes out at a consistent size. Combine them
-                    with --reduce or --enlarge to leave images that already fit untouched."#})
+                    with --reduce-only or --enlarge-only to leave images that already fit untouched."#})
                     .value_parser(value_parser!(ResizeValue))
                     .action(ArgAction::Append),
 
@@ -55,12 +55,12 @@ impl Preprocessors for Command {
                     .overrides_with("no-downscale"),
                 #[cfg(feature = "resize")]
                 arg!(--"no-downscale" "Disable downscaling when resizing.")
-                    .long_help(indoc! {r#"Disable downscaling when resizing. [aliases: --enlarge]
+                    .long_help(indoc! {r#"Disable downscaling when resizing. [aliases: --enlarge-only]
 
                     This is useful when you don't want to reduce the size of the image when it is larger than the specified size.
                     Images that are already larger than the specified size are left untouched, so this is the enlarge only mode.
                     It is recommended to use this option with --resize"#})
-                    .visible_alias("enlarge")
+                    .visible_alias("enlarge-only")
                     .action(ArgAction::SetTrue)
                     .requires("resize"),
 
@@ -76,12 +76,12 @@ impl Preprocessors for Command {
                     .overrides_with("no-upscale"),
                 #[cfg(feature = "resize")]
                 arg!(--"no-upscale" "Disable upscaling when resizing.")
-                    .long_help(indoc! {r#"Disable upscaling when resizing. [aliases: --reduce]
+                    .long_help(indoc! {r#"Disable upscaling when resizing. [aliases: --reduce-only]
 
                     This is useful when you don't want to increase the size of the image when it is smaller than the specified size.
                     Images that are already smaller than the specified size are left untouched, so this is the reduce only mode.
                     It is recommended to use this option with --resize"#})
-                    .visible_alias("reduce")
+                    .visible_alias("reduce-only")
                     .action(ArgAction::SetTrue)
                     .requires("resize"),
 

--- a/src/cli/preprocessors/mod.rs
+++ b/src/cli/preprocessors/mod.rs
@@ -33,7 +33,13 @@ impl Preprocessors for Command {
                     - 150%:    Adjust image size by this percentage
                     - 100x100: Resize image to Width×Height
                     - 100w:    Adjust image dimensions while maintaining the aspect ratio based on the width
-                    - 100h:    Adjust image dimensions while maintaining the aspect ratio based on the height"#})
+                    - 100h:    Adjust image dimensions while maintaining the aspect ratio based on the height
+                    - 100l:    Adjust image dimensions while maintaining the aspect ratio based on the longest side
+                    - 100s:    Adjust image dimensions while maintaining the aspect ratio based on the shortest side
+
+                    The longest and shortest side values pick the anchor per image, so a batch of
+                    mixed portrait and landscape images comes out at a consistent size. Combine them
+                    with --no-upscale or --no-downscale to leave images that already fit untouched."#})
                     .value_parser(value_parser!(ResizeValue))
                     .action(ArgAction::Append),
 

--- a/src/cli/preprocessors/resize/value.rs
+++ b/src/cli/preprocessors/resize/value.rs
@@ -5,7 +5,6 @@ use regex::Regex;
 
 static WIDTH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?P<width>\d+)").unwrap());
 static HEIGHT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?P<height>\d+)").unwrap());
-static SIDE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?P<side>\d+)").unwrap());
 
 /// Markers that select which dimension a resize value is anchored to.
 /// Only one of them may appear in a single value.
@@ -84,14 +83,22 @@ fn scale_side(width: usize, height: usize, side: usize, anchor_is_width: bool) -
 
 /// Extracts the side length from a longest/shortest side value.
 ///
+/// The marker may sit on either end of the digits, the same spellings the width
+/// and height values accept, but nothing else may appear in the value. Pulling
+/// the first run of digits out of anything else would silently accept typos
+/// like `1.5l`, which would resize down to a single pixel.
+///
 /// A zero length is rejected here rather than at resize time, because it can
 /// never produce a valid image and the error is clearer next to the input.
-fn parse_side(s: &str) -> Result<usize, anyhow::Error> {
-    let Some(cap) = SIDE_RE.captures(s) else {
+fn parse_side(s: &str, marker: char) -> Result<usize, anyhow::Error> {
+    let Some(digits) = s.strip_prefix(marker).or_else(|| s.strip_suffix(marker)) else {
         return Err(anyhow!("Invalid resize value"));
     };
 
-    let side: usize = cap["side"].parse()?;
+    let side: usize = digits
+        .trim()
+        .parse()
+        .map_err(|_| anyhow!("Invalid resize value"))?;
 
     if side == 0 {
         return Err(anyhow!("Side length should be greater than 0"));
@@ -150,8 +157,8 @@ impl std::str::FromStr for ResizeValue {
 
                 Ok(Self::Dimensions(None, Some(cap["height"].parse()?)))
             }
-            s if s.contains('l') => Ok(Self::LongestSide(parse_side(&s)?)),
-            s if s.contains('s') => Ok(Self::ShortestSide(parse_side(&s)?)),
+            s if s.contains('l') => Ok(Self::LongestSide(parse_side(&s, 'l')?)),
+            s if s.contains('s') => Ok(Self::ShortestSide(parse_side(&s, 's')?)),
             s if s.contains('x') => {
                 let dimensions: Vec<&str> = s.split('x').collect();
                 if dimensions.len() > 2 {
@@ -325,6 +332,21 @@ mod tests {
     fn from_str_side_rejects_zero() {
         assert!("0l".parse::<ResizeValue>().is_err());
         assert!("0s".parse::<ResizeValue>().is_err());
+    }
+
+    #[test]
+    fn from_str_side_rejects_anything_around_the_digits() {
+        // Taking the first run of digits out of the value would turn `1.5l`
+        // into a single pixel image instead of an error.
+        for value in [
+            "1.5l", "1.5s", "200l300", "200s300", "abc200l", "200sfoo", "2 0 0 l", "200.l",
+            "200lol", "l200l",
+        ] {
+            assert!(
+                value.parse::<ResizeValue>().is_err(),
+                "{value} should not parse"
+            );
+        }
     }
 
     #[test]

--- a/src/cli/preprocessors/resize/value.rs
+++ b/src/cli/preprocessors/resize/value.rs
@@ -5,12 +5,21 @@ use regex::Regex;
 
 static WIDTH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?P<width>\d+)").unwrap());
 static HEIGHT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?P<height>\d+)").unwrap());
+static SIDE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?P<side>\d+)").unwrap());
+
+/// Markers that select which dimension a resize value is anchored to.
+/// Only one of them may appear in a single value.
+const ANCHOR_MARKERS: [char; 4] = ['w', 'h', 'l', 's'];
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ResizeValue {
     Multiplier(f32),
     Percentage(f32),
     Dimensions(Option<usize>, Option<usize>),
+    /// Resize so that the longer of the two sides becomes this length.
+    LongestSide(usize),
+    /// Resize so that the shorter of the two sides becomes this length.
+    ShortestSide(usize),
 }
 
 impl ResizeValue {
@@ -42,8 +51,53 @@ impl ResizeValue {
 
                 (width, height)
             }
+
+            // Which side is the longest depends on the image, so the anchored
+            // side is picked per image instead of being fixed by the value.
+            ResizeValue::LongestSide(side) => scale_side(width, height, *side, width >= height),
+            ResizeValue::ShortestSide(side) => scale_side(width, height, *side, width <= height),
         }
     }
+}
+
+/// Scales an image so that one of its sides becomes `side`, preserving the aspect ratio.
+///
+/// `anchor_is_width` selects the side that is pinned to `side`. The other one is
+/// derived from the aspect ratio and never drops below a single pixel, which
+/// would otherwise fail the resize on extremely elongated images.
+fn scale_side(width: usize, height: usize, side: usize, anchor_is_width: bool) -> (usize, usize) {
+    // A degenerate image has no aspect ratio to preserve.
+    if width == 0 || height == 0 {
+        return (width, height);
+    }
+
+    if anchor_is_width {
+        let new_height = (side as f32 * height as f32 / width as f32) as usize;
+
+        (side, new_height.max(1))
+    } else {
+        let new_width = (side as f32 * width as f32 / height as f32) as usize;
+
+        (new_width.max(1), side)
+    }
+}
+
+/// Extracts the side length from a longest/shortest side value.
+///
+/// A zero length is rejected here rather than at resize time, because it can
+/// never produce a valid image and the error is clearer next to the input.
+fn parse_side(s: &str) -> Result<usize, anyhow::Error> {
+    let Some(cap) = SIDE_RE.captures(s) else {
+        return Err(anyhow!("Invalid resize value"));
+    };
+
+    let side: usize = cap["side"].parse()?;
+
+    if side == 0 {
+        return Err(anyhow!("Side length should be greater than 0"));
+    }
+
+    Ok(side)
 }
 
 impl std::fmt::Display for ResizeValue {
@@ -57,6 +111,8 @@ impl std::fmt::Display for ResizeValue {
             ResizeValue::Dimensions(Some(width), None) => f.write_fmt(format_args!("{width}w")),
             ResizeValue::Dimensions(None, Some(height)) => f.write_fmt(format_args!("{height}h")),
             ResizeValue::Dimensions(None, None) => f.write_fmt(format_args!("base")),
+            ResizeValue::LongestSide(side) => f.write_fmt(format_args!("{side}l")),
+            ResizeValue::ShortestSide(side) => f.write_fmt(format_args!("{side}s")),
         }
     }
 }
@@ -70,7 +126,16 @@ impl std::str::FromStr for ResizeValue {
         match s {
             s if s.starts_with('@') => Ok(Self::Multiplier(s[1..].parse()?)),
             s if s.ends_with('%') => Ok(Self::Percentage(s[..s.len() - 1].parse()?)),
-            s if s.contains('w') && s.contains('h') => Err(anyhow!("Invalid resize value")),
+            s if ANCHOR_MARKERS
+                .iter()
+                .filter(|marker| s.contains(**marker))
+                .count()
+                > 1 =>
+            {
+                Err(anyhow!(
+                    "Resize value can be anchored to only one of width, height, longest or shortest side"
+                ))
+            }
             s if s.contains('w') => {
                 let Some(cap) = WIDTH_RE.captures(&s) else {
                     return Err(anyhow!("Invalid resize value"));
@@ -85,6 +150,8 @@ impl std::str::FromStr for ResizeValue {
 
                 Ok(Self::Dimensions(None, Some(cap["height"].parse()?)))
             }
+            s if s.contains('l') => Ok(Self::LongestSide(parse_side(&s)?)),
+            s if s.contains('s') => Ok(Self::ShortestSide(parse_side(&s)?)),
             s if s.contains('x') => {
                 let dimensions: Vec<&str> = s.split('x').collect();
                 if dimensions.len() > 2 {
@@ -130,6 +197,12 @@ mod tests {
         assert_eq!(ResizeValue::Dimensions(Some(150), None).to_string(), "150w");
 
         assert_eq!(ResizeValue::Dimensions(None, None).to_string(), "base");
+
+        assert_eq!(ResizeValue::LongestSide(200).to_string(), "200l");
+        assert_eq!(ResizeValue::LongestSide(150).to_string(), "150l");
+
+        assert_eq!(ResizeValue::ShortestSide(200).to_string(), "200s");
+        assert_eq!(ResizeValue::ShortestSide(150).to_string(), "150s");
     }
 
     #[test]
@@ -204,8 +277,234 @@ mod tests {
             ResizeValue::Dimensions(None, Some(150))
         );
 
+        assert_eq!(
+            "200l".parse::<ResizeValue>().unwrap(),
+            ResizeValue::LongestSide(200)
+        );
+
+        assert_eq!(
+            "150l".parse::<ResizeValue>().unwrap(),
+            ResizeValue::LongestSide(150)
+        );
+
+        assert_eq!(
+            "200s".parse::<ResizeValue>().unwrap(),
+            ResizeValue::ShortestSide(200)
+        );
+
+        assert_eq!(
+            "150s".parse::<ResizeValue>().unwrap(),
+            ResizeValue::ShortestSide(150)
+        );
+
         assert!("_x_".parse::<ResizeValue>().is_err());
         assert!("150wh".parse::<ResizeValue>().is_err());
+    }
+
+    #[test]
+    fn from_str_side_accepts_same_shapes_as_width_and_height() {
+        // Whatever spelling works for `100w` should work for the side values too.
+        for value in ["200l", "200 l", "l200", "200L", "200 L", "L200"] {
+            assert_eq!(
+                value.parse::<ResizeValue>().unwrap(),
+                ResizeValue::LongestSide(200),
+                "failed to parse {value}"
+            );
+        }
+
+        for value in ["200s", "200 s", "s200", "200S", "200 S", "S200"] {
+            assert_eq!(
+                value.parse::<ResizeValue>().unwrap(),
+                ResizeValue::ShortestSide(200),
+                "failed to parse {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_side_rejects_zero() {
+        assert!("0l".parse::<ResizeValue>().is_err());
+        assert!("0s".parse::<ResizeValue>().is_err());
+    }
+
+    #[test]
+    fn from_str_side_rejects_missing_length() {
+        assert!("l".parse::<ResizeValue>().is_err());
+        assert!("s".parse::<ResizeValue>().is_err());
+    }
+
+    #[test]
+    fn from_str_rejects_multiple_anchors() {
+        for value in [
+            "150ls", "150wl", "150ws", "150hl", "150hs", "150wh", "150lw", "150sh",
+        ] {
+            assert!(
+                value.parse::<ResizeValue>().is_err(),
+                "{value} should not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_still_accepts_values_without_anchors() {
+        // The anchor check runs before every dimension branch, so make sure it
+        // does not reject the values that carry no anchor marker at all.
+        assert_eq!(
+            "100x100".parse::<ResizeValue>().unwrap(),
+            ResizeValue::Dimensions(Some(100), Some(100))
+        );
+
+        assert_eq!(
+            "@2".parse::<ResizeValue>().unwrap(),
+            ResizeValue::Multiplier(2.)
+        );
+
+        assert_eq!(
+            "150%".parse::<ResizeValue>().unwrap(),
+            ResizeValue::Percentage(150.)
+        );
+    }
+
+    #[test]
+    fn display_round_trips_through_from_str() {
+        for value in [
+            ResizeValue::Multiplier(1.5),
+            ResizeValue::Percentage(150.),
+            ResizeValue::Dimensions(Some(100), Some(200)),
+            ResizeValue::Dimensions(Some(100), None),
+            ResizeValue::Dimensions(None, Some(200)),
+            ResizeValue::LongestSide(1000),
+            ResizeValue::ShortestSide(1000),
+        ] {
+            assert_eq!(
+                value.to_string().parse::<ResizeValue>().unwrap(),
+                value,
+                "{value} did not round trip"
+            );
+        }
+    }
+
+    #[test]
+    fn map_dimensions_longest_side() {
+        let resize_value = ResizeValue::LongestSide(100);
+
+        // Landscape anchors on the width, portrait on the height, and the
+        // result has the same longest side either way.
+        assert_eq!(resize_value.map_dimensions(1000, 500), (100, 50));
+        assert_eq!(resize_value.map_dimensions(500, 1000), (50, 100));
+        assert_eq!(resize_value.map_dimensions(800, 800), (100, 100));
+    }
+
+    #[test]
+    fn map_dimensions_shortest_side() {
+        let resize_value = ResizeValue::ShortestSide(100);
+
+        assert_eq!(resize_value.map_dimensions(1000, 500), (200, 100));
+        assert_eq!(resize_value.map_dimensions(500, 1000), (100, 200));
+        assert_eq!(resize_value.map_dimensions(800, 800), (100, 100));
+    }
+
+    #[test]
+    fn map_dimensions_side_upscales() {
+        assert_eq!(
+            ResizeValue::LongestSide(1000).map_dimensions(100, 50),
+            (1000, 500)
+        );
+
+        assert_eq!(
+            ResizeValue::ShortestSide(1000).map_dimensions(100, 50),
+            (2000, 1000)
+        );
+    }
+
+    #[test]
+    fn map_dimensions_side_is_a_noop_when_the_image_already_fits() {
+        // The pipeline skips the resize when the mapped size equals the source,
+        // so this is what makes an already correct image untouched.
+        assert_eq!(
+            ResizeValue::LongestSide(1000).map_dimensions(1000, 500),
+            (1000, 500)
+        );
+
+        assert_eq!(
+            ResizeValue::ShortestSide(500).map_dimensions(1000, 500),
+            (1000, 500)
+        );
+
+        assert_eq!(
+            ResizeValue::LongestSide(800).map_dimensions(800, 800),
+            (800, 800)
+        );
+    }
+
+    #[test]
+    fn map_dimensions_side_never_returns_zero() {
+        // Extreme aspect ratios truncate the derived side to zero, which the
+        // resize operation rejects outright.
+        assert_eq!(
+            ResizeValue::LongestSide(10).map_dimensions(1000, 3),
+            (10, 1)
+        );
+        assert_eq!(
+            ResizeValue::LongestSide(10).map_dimensions(3, 1000),
+            (1, 10)
+        );
+        assert_eq!(
+            ResizeValue::LongestSide(1).map_dimensions(1000, 1000),
+            (1, 1)
+        );
+    }
+
+    #[test]
+    fn map_dimensions_side_preserves_aspect_ratio() {
+        for (width, height) in [(1920, 1080), (1080, 1920), (640, 640), (3000, 2000)] {
+            for side in [50, 100, 512, 4000] {
+                for value in [
+                    ResizeValue::LongestSide(side),
+                    ResizeValue::ShortestSide(side),
+                ] {
+                    let (new_width, new_height) = value.map_dimensions(width, height);
+
+                    let source_ratio = width as f32 / height as f32;
+                    let result_ratio = new_width as f32 / new_height as f32;
+
+                    // Truncation moves the derived side by at most a pixel, so
+                    // compare with a tolerance scaled to the smaller result.
+                    let tolerance = source_ratio / new_width.min(new_height) as f32;
+
+                    assert!(
+                        (source_ratio - result_ratio).abs() <= tolerance,
+                        "{value} on {width}x{height} gave {new_width}x{new_height}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn map_dimensions_side_anchors_the_expected_side() {
+        for (width, height) in [(1920, 1080), (1080, 1920), (640, 640), (3000, 2000)] {
+            let (new_width, new_height) =
+                ResizeValue::LongestSide(512).map_dimensions(width, height);
+            assert_eq!(new_width.max(new_height), 512);
+
+            let (new_width, new_height) =
+                ResizeValue::ShortestSide(512).map_dimensions(width, height);
+            assert_eq!(new_width.min(new_height), 512);
+        }
+    }
+
+    #[test]
+    fn map_dimensions_side_leaves_degenerate_images_alone() {
+        assert_eq!(
+            ResizeValue::LongestSide(100).map_dimensions(0, 500),
+            (0, 500)
+        );
+        assert_eq!(
+            ResizeValue::ShortestSide(100).map_dimensions(500, 0),
+            (500, 0)
+        );
+        assert_eq!(ResizeValue::LongestSide(100).map_dimensions(0, 0), (0, 0));
     }
 
     #[test]


### PR DESCRIPTION
Closes #357.

Adds `100l` and `100s` to `--resize`, plus `--reduce-only` and `--enlarge-only` as aliases for the existing `--no-upscale` and `--no-downscale`. No new flags.

```sh
# longest side becomes 1000, aspect ratio preserved
rimage mozjpeg --resize 1000l ./images

# shortest side becomes 1000
rimage mozjpeg --resize 1000s ./images

# shrink oversized images only, anything already under 1000 keeps its original size
rimage mozjpeg --resize 1000l --reduce-only ./images
```

### Why the existing values are not enough

`100w` fixes the anchor to the width for every image in the batch. With mixed orientation that makes portrait images far taller than the landscape ones are wide, so nothing comes out at a consistent size. `100l` and `100s` pick the anchored side per image instead.

Same idea as ImageMagick's geometry suffixes: https://imagemagick.org/script/command-line-processing.php#geometry

### Implementation

Two new `ResizeValue` variants and one helper in `src/cli/preprocessors/resize/value.rs`. `map_dimensions` decides per image whether the target length lands on the width or the height, then derives the other side from the aspect ratio.

The skip conditions in `pipeline.rs` are untouched. They already do the right thing for these values, because both axes scale in the same direction, so `--no-upscale` skips an image whose relevant side is already at or below the target and `--no-downscale` is the mirror of that.

Three guards that the existing `100w` path does not have:

- The value has to be digits with the marker at one end, nothing else. Pulling the first run of digits out of anything else accepts typos like `1.5l`, which resizes down to a single pixel. `100w` still does this, tracked separately in #378.
- The derived side is clamped to a minimum of one pixel. Truncation puts it at zero on extremely elongated images, and `Resize` rejects a zero dimension.
- A side length of `0` is rejected at parse time rather than at resize time, so the error appears next to the input that caused it.

> **Note**: parsing lowercases the input first, so `1000L` and `1000l` are the same value. The check that rejects two anchors in one value now covers `w`, `h`, `l` and `s`, which replaces the old `w` plus `h` check and keeps `150wh` invalid.

### The --reduce-only and --enlarge-only aliases

`--no-upscale` and `--no-downscale` name the direction that is disabled, so reading either one means inverting twice to arrive at the mode that is left. The aliases name the mode directly, and match the wording batch converters use for the same pair of options, including the one in the screenshot on #357.

These are `visible_alias` entries, so the argument ids and all the flag handling stay exactly as they were. Nothing about the existing spellings changes.

```
--no-downscale    Disable downscaling when resizing. [aliases: --enlarge-only]
--no-upscale      Disable upscaling when resizing. [aliases: --reduce-only]
```

### Tests

34 new tests, all in the binary crate.

Unit tests in `value.rs` cover parsing (every spelling that `100w` accepts, case insensitivity, zero, missing length, conflicting anchors, and ten malformed values that must not parse), display round trips, and the dimension mapping across landscape, portrait and square inputs, including upscaling, the already fits no-op, the one pixel clamp, aspect ratio preservation over a grid of sizes, and degenerate images with a zero dimension.

Integration tests in `pipeline.rs` drive real CLI arguments through `operations()` and execute the queued operations, asserting both the resulting dimensions and whether a resize was queued at all. That second part is what pins the "already fits" behaviour, since leaving an image alone means no operation is queued.

The aliases get three tests: each one is asserted to produce results identical to the flag it aliases across several image sizes, and a third checks that each alias moves images in the direction its name promises, which is the one thing that could silently go wrong when naming a double negative.

Full suite, `cargo test --features build-binary`:

```
running 42 tests
test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.60s
running 56 tests
test result: ok. 56 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 16.47s
running 6 tests
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.22s
running 5 tests
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
```

`cargo fmt` and `cargo clippy --features build-binary --all-targets` are clean.

### Manual check

Three fixtures, 800x400, 400x800 and 120x80:

```
--resize 200l:
  landscape.jpg  200x100
  portrait.jpg   100x200
  small.jpg      200x133

--resize 200s:
  landscape.jpg  400x200
  portrait.jpg   200x400
  small.jpg      300x200

--resize 200l --reduce-only:
  landscape.jpg  200x100
  portrait.jpg   100x200
  small.jpg      120x80

--resize 200l --enlarge-only:
  landscape.jpg  800x400
  portrait.jpg   400x800
  small.jpg      200x133
```

Rejected values:

```
1.5l       error: invalid value '1.5l' for '--resize <RESIZE>': Invalid resize value
200l300    error: invalid value '200l300' for '--resize <RESIZE>': Invalid resize value
200sfoo    error: invalid value '200sfoo' for '--resize <RESIZE>': Invalid resize value
0l         error: invalid value '0l' for '--resize <RESIZE>': Side length should be greater than 0
100ls      error: invalid value '100ls' for '--resize <RESIZE>': Resize value can be anchored to only one of width, height, longest or shortest side
```

---

@Mikachu2333 you raised the argument surface concern on the issue, and this is my attempt at the version that does not grow it. Is `1000l` / `1000s` fine as naming, or would you prefer something closer to the ImageMagick geometry syntax?