### PR TITLE
chore: :bookmark: bump version to v0.13.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           >> "$GITHUB_OUTPUT"
 
       - name: create release notes
-        run: tail -n +5 CHANGELOG.md | sed -e '/## \[v/,$d' > RELEASE_NOTES.txt
+        run: tail -n +6 CHANGELOG.md | sed -e '/^#\{1,2\} /,$d' > RELEASE_NOTES.txt
 
       - name: create release
         uses: softprops/action-gh-release@v3
@@ -94,7 +94,7 @@ jobs:
           esac
 
       - name: create release notes
-        run: tail -n +5 CHANGELOG.md | sed -e '/## \[v/,$d' > RELEASE_NOTES.txt
+        run: tail -n +6 CHANGELOG.md | sed -e '/^#\{1,2\} /,$d' > RELEASE_NOTES.txt
 
       - name: create release
         uses: softprops/action-gh-release@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Rimage library will be documented in this file.
 
-# 0.13.0
+# [0.13.0](https://github.com/SalOne22/rimage/compare/v0.12.4...v0.13.0) (2026-08-14)
 
 ### Breaking Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "rimage"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "rimage"
-version       = "0.12.4"
+version       = "0.13.0"
 edition       = "2024"
 description   = "Optimize images natively with best-in-class codecs"
 license       = "MIT OR Apache-2.0"


### PR DESCRIPTION
Finalize the 0.13.0 changelog entry with the compare link and release
date, and bump the crate version in Cargo.toml and Cargo.lock.

Also fix the release notes extraction in the deploy workflow. The sed
pattern looked for `## [v` headers, but entries since 0.12.1 use a
single `#`, so the notes for a new release also carried the 0.12.x
sections. Skip the title block plus the newest version header, then cut
at the next `#`/`##` header.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xyj5Uc14HXhNJ42GTwHaUc